### PR TITLE
(Aiven) KIP-710: Fix intra-cluster communication for dedicated MirrorMaker 2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2802,6 +2802,17 @@ project(':connect:mirror') {
     implementation libs.argparse4j
     implementation libs.jacksonAnnotations
     implementation libs.slf4jApi
+    implementation libs.jacksonAnnotations
+    implementation libs.jacksonJaxrsJsonProvider
+    implementation libs.jerseyContainerServlet
+    implementation libs.jerseyHk2
+    implementation libs.jaxbApi // Jersey dependency that was available in the JDK before Java 9
+    implementation libs.activation // Jersey dependency that was available in the JDK before Java 9
+    implementation libs.jettyServer
+    implementation libs.jettyServlet
+    implementation libs.jettyServlets
+    implementation libs.jettyClient
+    implementation libs.swaggerAnnotations
 
     testImplementation libs.junitJupiter
     testImplementation libs.mockitoCore

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -560,6 +560,13 @@
       <allow pkg="org.apache.kafka.connect.integration" />
       <allow pkg="org.apache.kafka.connect.mirror" />
       <allow pkg="kafka.server" />
+      <subpackage name="rest">
+        <allow pkg="javax.ws.rs" />
+        <allow pkg="com.fasterxml.jackson" />
+        <subpackage name="resources">
+          <allow pkg="io.swagger.v3.oas.annotations"/>
+        </subpackage>
+      </subpackage>
     </subpackage>
 
     <subpackage name="runtime">

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
@@ -298,6 +298,8 @@ public class MirrorMaker {
                 // URLs
                 // So to get around that, we replace pluses in the encoded URL here with '%20',
                 // which is the encoding that Jetty expects for spaces
+                // Jetty will reverse this transformation when evaluating the path parameters
+                // and will return decoded strings with all special characters as they were.
                 .replaceAll("\\+", "%20");
     }
 

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
@@ -19,6 +19,7 @@ package org.apache.kafka.connect.mirror;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.common.utils.Exit;
+import org.apache.kafka.connect.mirror.rest.MirrorRestServer;
 import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.Worker;
@@ -46,6 +47,9 @@ import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.ArgumentParsers;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -103,11 +107,12 @@ public class MirrorMaker {
     private CountDownLatch stopLatch;
     private final AtomicBoolean shutdown = new AtomicBoolean(false);
     private final ShutdownHook shutdownHook;
-    private final String advertisedBaseUrl;
+    private final String advertisedUrl;
     private final Time time;
     private final MirrorMakerConfig config;
     private final Set<String> clusters;
     private final Set<SourceAndTarget> herderPairs;
+    private final MirrorRestServer internalServer;
 
     /**
      * @param config    MM2 configuration from mm2.properties file
@@ -119,7 +124,14 @@ public class MirrorMaker {
     public MirrorMaker(MirrorMakerConfig config, List<String> clusters, Time time) {
         log.debug("Kafka MirrorMaker instance created");
         this.time = time;
-        this.advertisedBaseUrl = "NOTUSED";
+        if (config.enableInternalRest()) {
+            internalServer = new MirrorRestServer(config.originals());
+            internalServer.initializeServer();
+            this.advertisedUrl = internalServer.advertisedUrl().toString();
+        } else {
+            internalServer = null;
+            this.advertisedUrl = "NOTUSED";
+        }
         this.config = config;
         if (clusters != null && !clusters.isEmpty()) {
             this.clusters = new HashSet<>(clusters);
@@ -173,6 +185,10 @@ public class MirrorMaker {
                 startLatch.countDown();
             }
         }
+        if (internalServer != null) {
+            log.info("Initializing internal REST resources");
+            internalServer.initializeInternalResources(herders);
+        }
         log.info("Configuring connectors...");
         herderPairs.forEach(this::configureConnectors);
         log.info("Kafka MirrorMaker started");
@@ -182,6 +198,9 @@ public class MirrorMaker {
         boolean wasShuttingDown = shutdown.getAndSet(true);
         if (!wasShuttingDown) {
             log.info("Kafka MirrorMaker stopping");
+            if (internalServer != null) {
+                Utils.closeQuietly(internalServer::stop, "Internal REST server");
+            }
             for (Herder herder : herders.values()) {
                 try {
                     herder.stop();
@@ -206,11 +225,13 @@ public class MirrorMaker {
         Map<String, String> connectorProps = config.connectorBaseConfig(sourceAndTarget, connectorClass);
         herders.get(sourceAndTarget)
                 .putConnectorConfig(connectorClass.getSimpleName(), connectorProps, true, (e, x) -> {
-                    if (e instanceof NotLeaderException) {
-                        // No way to determine if the connector is a leader or not beforehand.
-                        log.info("Connector {} is a follower. Using existing configuration.", sourceAndTarget);
+                    if (e == null) {
+                        log.info("{} connector configured for {}.", connectorClass.getSimpleName(), sourceAndTarget);
+                    } else if (e instanceof NotLeaderException) {
+                        // No way to determine if the herder is a leader or not beforehand.
+                        log.info("This node is a follower for {}. Using existing connector configuration.", sourceAndTarget);
                     } else {
-                        log.info("Connector {} configured.", sourceAndTarget, e);
+                        log.error("Failed to configure {} connector for {}", connectorClass.getSimpleName(), sourceAndTarget, e);
                     }
                 });
     }
@@ -228,7 +249,14 @@ public class MirrorMaker {
     private void addHerder(SourceAndTarget sourceAndTarget) {
         log.info("creating herder for " + sourceAndTarget.toString());
         Map<String, String> workerProps = config.workerConfig(sourceAndTarget);
-        String advertisedUrl = advertisedBaseUrl + "/" + sourceAndTarget.source();
+        List<String> restNamespace;
+        try {
+            String encodedSource = encodePath(sourceAndTarget.source());
+            String encodedTarget = encodePath(sourceAndTarget.target());
+            restNamespace = Arrays.asList(encodedSource, encodedTarget);
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("Unable to create encoded URL paths for source and target using UTF-8", e);
+        }
         String workerId = sourceAndTarget.toString();
         Plugins plugins = new Plugins(workerProps);
         plugins.compareAndSwapWithDelegatingLoader();
@@ -257,8 +285,20 @@ public class MirrorMaker {
         // tracking the various shared admin objects in this class.
         Herder herder = new DistributedHerder(distributedConfig, time, worker,
                 kafkaClusterId, statusBackingStore, configBackingStore,
-                advertisedUrl, CLIENT_CONFIG_OVERRIDE_POLICY, sharedAdmin);
+                advertisedUrl, CLIENT_CONFIG_OVERRIDE_POLICY,
+                restNamespace, sharedAdmin);
         herders.put(sourceAndTarget, herder);
+    }
+
+    private static String encodePath(String rawPath) throws UnsupportedEncodingException {
+        return URLEncoder.encode(rawPath, StandardCharsets.UTF_8.name())
+                // Java's out-of-the-box URL encoder encodes spaces (' ') as pluses ('+'),
+                // and pluses as '%2B'
+                // But Jetty doesn't decode pluses at all and leaves them as-are in decoded
+                // URLs
+                // So to get around that, we replace pluses in the encoded URL here with '%20',
+                // which is the encoding that Jetty expects for spaces
+                .replaceAll("\\+", "%20");
     }
 
     private class ShutdownHook extends Thread {
@@ -299,7 +339,7 @@ public class MirrorMaker {
 
             Properties props = Utils.loadProps(configFile.getPath());
             Map<String, String> config = Utils.propsToStringMap(props);
-            MirrorMaker mirrorMaker = new MirrorMaker(config, clusters, Time.SYSTEM);
+            MirrorMaker mirrorMaker = new MirrorMaker(config, clusters);
             
             try {
                 mirrorMaker.start();

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMakerConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMakerConfig.java
@@ -30,6 +30,7 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
+import org.apache.kafka.connect.runtime.rest.RestServerConfig;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -79,16 +80,23 @@ public class MirrorMakerConfig extends AbstractConfig {
     static final String TARGET_CLUSTER_PREFIX = "target.cluster.";
     static final String SOURCE_PREFIX = "source.";
     static final String TARGET_PREFIX = "target.";
+    static final String ENABLE_INTERNAL_REST_CONFIG = "mm.enable.internal.rest";
+    private static final String ENABLE_INTERNAL_REST_DOC =
+            "Whether to bring up an internal-only REST server that allows multi-node clusters to operate correctly";
 
     private final Plugins plugins;
    
     public MirrorMakerConfig(Map<?, ?> props) {
-        super(CONFIG_DEF, props, true);
+        super(config(), props, true);
         plugins = new Plugins(originalsStrings());
     }
 
     public Set<String> clusters() {
         return new HashSet<>(getList(CLUSTERS_CONFIG));
+    }
+
+    public boolean enableInternalRest() {
+        return getBoolean(ENABLE_INTERNAL_REST_CONFIG);
     }
 
     public List<SourceAndTarget> clusterPairs() {
@@ -257,20 +265,25 @@ public class MirrorMakerConfig extends AbstractConfig {
         providers.values().forEach(x -> Utils.closeQuietly(x, "config provider"));
         return transformed;
     }
- 
-    protected static final ConfigDef CONFIG_DEF = new ConfigDef()
-            .define(CLUSTERS_CONFIG, Type.LIST, Importance.HIGH, CLUSTERS_DOC)
-            .define(CONFIG_PROVIDERS_CONFIG, Type.LIST, Collections.emptyList(), Importance.LOW, CONFIG_PROVIDERS_DOC)
-            // security support
-            .define(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG,
-                Type.STRING,
-                CommonClientConfigs.DEFAULT_SECURITY_PROTOCOL,
-                in(Utils.enumOptions(SecurityProtocol.class)),
-                Importance.MEDIUM,
-                CommonClientConfigs.SECURITY_PROTOCOL_DOC)
-            .withClientSslSupport()
-            .withClientSaslSupport();
 
+    protected static ConfigDef config() {
+        ConfigDef result = new ConfigDef()
+                .define(CLUSTERS_CONFIG, Type.LIST, Importance.HIGH, CLUSTERS_DOC)
+                .define(ENABLE_INTERNAL_REST_CONFIG, Type.BOOLEAN, false, Importance.HIGH, ENABLE_INTERNAL_REST_DOC)
+                .define(CONFIG_PROVIDERS_CONFIG, Type.LIST, Collections.emptyList(), Importance.LOW, CONFIG_PROVIDERS_DOC)
+                // security support
+                .define(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG,
+                        Type.STRING,
+                        CommonClientConfigs.DEFAULT_SECURITY_PROTOCOL,
+                        in(Utils.enumOptions(SecurityProtocol.class)),
+                        Importance.MEDIUM,
+                        CommonClientConfigs.SECURITY_PROTOCOL_DOC)
+                .withClientSslSupport()
+                .withClientSaslSupport();
+        RestServerConfig.addInternalConfig(result);
+        return result;
+    }
+ 
     private Map<String, String> stringsWithPrefixStripped(String prefix) {
         return originalsStrings().entrySet().stream()
             .filter(x -> x.getKey().startsWith(prefix))

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/rest/MirrorRestServer.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/rest/MirrorRestServer.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror.rest;
+
+import org.apache.kafka.connect.mirror.SourceAndTarget;
+import org.apache.kafka.connect.mirror.rest.resources.InternalConnectorsResource;
+import org.apache.kafka.connect.runtime.Herder;
+import org.apache.kafka.connect.runtime.rest.RestServer;
+import org.apache.kafka.connect.runtime.rest.RestServerConfig;
+import org.apache.kafka.connect.runtime.rest.resources.ConnectResource;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+public class MirrorRestServer extends RestServer {
+
+    private Map<SourceAndTarget, Herder> herders;
+
+    public MirrorRestServer(Map<?, ?> props) {
+        super(RestServerConfig.forInternal(props));
+    }
+
+    public void initializeInternalResources(Map<SourceAndTarget, Herder> herders) {
+        this.herders = herders;
+        super.initializeResources();
+    }
+
+    @Override
+    protected Collection<ConnectResource> regularResources() {
+        return Arrays.asList(
+                new InternalConnectorsResource(herders, config)
+        );
+    }
+
+    @Override
+    protected Collection<ConnectResource> adminResources() {
+        return Collections.emptyList();
+    }
+
+}

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/rest/MirrorRestServer.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/rest/MirrorRestServer.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.connect.mirror.rest;
 
 import org.apache.kafka.connect.mirror.SourceAndTarget;
-import org.apache.kafka.connect.mirror.rest.resources.InternalConnectorsResource;
+import org.apache.kafka.connect.mirror.rest.resources.InternalMirrorResource;
 import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.rest.RestServer;
 import org.apache.kafka.connect.runtime.rest.RestServerConfig;
@@ -44,7 +44,7 @@ public class MirrorRestServer extends RestServer {
     @Override
     protected Collection<ConnectResource> regularResources() {
         return Arrays.asList(
-                new InternalConnectorsResource(herders, config)
+                new InternalMirrorResource(herders, config)
         );
     }
 

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/rest/resources/InternalConnectorsResource.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/rest/resources/InternalConnectorsResource.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror.rest.resources;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.connect.mirror.SourceAndTarget;
+import org.apache.kafka.connect.runtime.Herder;
+import org.apache.kafka.connect.runtime.rest.HerderRequestHandler;
+import org.apache.kafka.connect.runtime.rest.InternalRequestSignature;
+import org.apache.kafka.connect.runtime.rest.resources.ConnectResource;
+import org.apache.kafka.connect.util.FutureCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.Map;
+
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+public class InternalConnectorsResource implements ConnectResource {
+
+    private static final Logger log = LoggerFactory.getLogger(InternalConnectorsResource.class);
+
+    private static final TypeReference<List<Map<String, String>>> TASK_CONFIGS_TYPE =
+            new TypeReference<List<Map<String, String>>>() { };
+
+    private final Map<SourceAndTarget, Herder> herders;
+    private final HerderRequestHandler requestHandler;
+
+    public InternalConnectorsResource(Map<SourceAndTarget, Herder> herders, AbstractConfig serverConfig) {
+        this.herders = herders;
+        this.requestHandler = new HerderRequestHandler(serverConfig, DEFAULT_REST_REQUEST_TIMEOUT_MS);
+    }
+
+    @Override
+    public void requestTimeout(long requestTimeoutMs) {
+        requestHandler.requestTimeoutMs(requestTimeoutMs);
+    }
+
+    @POST
+    @Path("/{source}/{target}/connectors/{connector}/tasks")
+    @Operation(hidden = true, summary = "This operation is only for inter-worker communications")
+    public void putTaskConfigs(
+            final @PathParam("source") String source,
+            final @PathParam("target") String target,
+            final @PathParam("connector") String connector,
+            final @Context HttpHeaders headers,
+            final @QueryParam("forward") Boolean forward,
+            final byte[] requestBody) throws Throwable {
+        List<Map<String, String>> taskConfigs = new ObjectMapper().readValue(requestBody, TASK_CONFIGS_TYPE);
+        FutureCallback<Void> cb = new FutureCallback<>();
+        herder(source, target).putTaskConfigs(connector, taskConfigs, cb, InternalRequestSignature.fromHeaders(requestBody, headers));
+        requestHandler.completeOrForwardRequest(
+                cb,
+                source + "/" + target + "/connectors/" + connector + "/tasks",
+                "POST",
+                headers,
+                taskConfigs,
+                forward
+        );
+    }
+
+    @PUT
+    @Path("/{source}/{target}/connectors/{connector}/fence")
+    @Operation(hidden = true, summary = "This operation is only for inter-worker communications")
+    public void fenceZombies(
+            final @PathParam("source") String source,
+            final @PathParam("target") String target,
+            final @PathParam("connector") String connector,
+            final @Context HttpHeaders headers,
+            final @QueryParam("forward") Boolean forward,
+            final byte[] requestBody) throws Throwable {
+        FutureCallback<Void> cb = new FutureCallback<>();
+        herder(source, target).fenceZombieSourceTasks(connector, cb, InternalRequestSignature.fromHeaders(requestBody, headers));
+        requestHandler.completeOrForwardRequest(
+                cb,
+                source + "/" + target + "/connectors/" + connector + "/fence",
+                "PUT",
+                headers,
+                requestBody,
+                forward
+        );
+    }
+
+    private Herder herder(String source, String target) {
+        Herder result = herders.get(new SourceAndTarget(source, target));
+        if (result == null) {
+            log.debug("Failed to find herder for source '{}' and target '{}'", source, target);
+            throw new NotFoundException("No replication flow found for source '" + source + "' and target '" + target + "'");
+        }
+        return result;
+    }
+}

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/rest/resources/InternalMirrorResource.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/rest/resources/InternalMirrorResource.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror.rest.resources;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.connect.mirror.SourceAndTarget;
+import org.apache.kafka.connect.runtime.Herder;
+import org.apache.kafka.connect.runtime.rest.resources.InternalClusterResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+import java.util.List;
+import java.util.Map;
+
+@Path("/{source}/{target}/connectors")
+public class InternalMirrorResource extends InternalClusterResource {
+
+    @Context
+    private UriInfo uriInfo;
+
+    private static final Logger log = LoggerFactory.getLogger(InternalMirrorResource.class);
+
+    private final Map<SourceAndTarget, Herder> herders;
+
+    public InternalMirrorResource(Map<SourceAndTarget, Herder> herders, AbstractConfig serverConfig) {
+        super(serverConfig);
+        this.herders = herders;
+    }
+
+    @Override
+    protected Herder herderForRequest() {
+        String source = pathParam("source");
+        String target = pathParam("target");
+        Herder result = herders.get(new SourceAndTarget(source, target));
+        if (result == null) {
+            log.debug("Failed to find herder for source '{}' and target '{}'", source, target);
+            throw new NotFoundException("No replication flow found for source '" + source + "' and target '" + target + "'");
+        }
+        return result;
+    }
+
+    private String pathParam(String name) {
+        List<String> result = uriInfo.getPathParameters().get(name);
+        if (result == null || result.isEmpty())
+            throw new NotFoundException();
+        return result.get(0);
+    }
+
+}

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/DedicatedMirrorIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/DedicatedMirrorIntegrationTest.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror.integration;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.connect.mirror.MirrorMaker;
+import org.apache.kafka.connect.util.clusters.EmbeddedKafkaCluster;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
+import static org.apache.kafka.test.TestUtils.waitForCondition;
+
+@Tag("integration")
+public class DedicatedMirrorIntegrationTest {
+
+    private static final Logger log = LoggerFactory.getLogger(DedicatedMirrorIntegrationTest.class);
+
+    private static final int TOPIC_CREATION_TIMEOUT_MS = 30_000;
+    private static final int TOPIC_REPLICATION_TIMEOUT_MS = 30_000;
+
+    private Map<String, EmbeddedKafkaCluster> kafkaClusters;
+    private Map<String, MirrorMaker> mirrorMakers;
+
+    @BeforeEach
+    public void setup() {
+        kafkaClusters = new HashMap<>();
+        mirrorMakers = new HashMap<>();
+    }
+
+    @AfterEach
+    public void teardown() throws Throwable {
+        AtomicReference<Throwable> shutdownFailure = new AtomicReference<>();
+        mirrorMakers.forEach((name, mirrorMaker) ->
+            Utils.closeQuietly(mirrorMaker::stop, "MirrorMaker worker '" + name + "'", shutdownFailure)
+        );
+        kafkaClusters.forEach((name, kafkaCluster) ->
+            Utils.closeQuietly(kafkaCluster::stop, "Embedded Kafka cluster '" + name + "'", shutdownFailure)
+        );
+        if (shutdownFailure.get() != null) {
+            throw shutdownFailure.get();
+        }
+    }
+
+    private EmbeddedKafkaCluster startKafkaCluster(String name, int numBrokers, Properties brokerProperties) {
+        if (kafkaClusters.containsKey(name))
+            throw new IllegalStateException("Cannot register multiple Kafka clusters with the same name");
+
+        EmbeddedKafkaCluster result = new EmbeddedKafkaCluster(numBrokers, brokerProperties);
+        kafkaClusters.put(name, result);
+
+        result.start();
+
+        return result;
+    }
+
+    private MirrorMaker startMirrorMaker(String name, Map<String, String> mmProps) {
+        if (mirrorMakers.containsKey(name))
+            throw new IllegalStateException("Cannot register multiple MirrorMaker nodes with the same name");
+
+        MirrorMaker result = new MirrorMaker(mmProps);
+        mirrorMakers.put(name, result);
+
+        result.start();
+
+        return result;
+    }
+
+    /**
+     * Test that a multi-node dedicated cluster is able to dynamically detect new topics at runtime
+     * and reconfigure its connectors and their tasks to replicate those topics correctly.
+     * See <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-710%3A+Full+support+for+distributed+mode+in+dedicated+MirrorMaker+2.0+clusters">KIP-710</a>
+     * for more detail on the necessity for this test case.
+
+     */
+    @Test
+    public void testMultiNodeCluster() throws Exception {
+        Properties brokerProps = new Properties();
+        brokerProps.put("transaction.state.log.replication.factor", "1");
+        brokerProps.put("transaction.state.log.min.isr", "1");
+        EmbeddedKafkaCluster clusterA = startKafkaCluster("A", 1, brokerProps);
+        EmbeddedKafkaCluster clusterB = startKafkaCluster("B", 1, brokerProps);
+
+        clusterA.start();
+        clusterB.start();
+
+        try (Admin adminA = clusterA.createAdminClient();
+                Admin adminB = clusterB.createAdminClient()) {
+
+            // Cluster aliases
+            // Use weird names to ensure they're properly URL-encoded in cross-worker REST requests
+            final String a = "A";
+            final String b = "B";
+            final String ab = a + "->" + b;
+            final String ba = b + "->" + a;
+            final String testTopicPrefix = "test-topic-";
+
+            Map<String, String> mmProps = new HashMap<String, String>() {{
+                    put("mm.enable.internal.rest", "true");
+                    put("listeners", "http://localhost:0");
+                    put("refresh.topics.interval.seconds", "1");
+                    put("clusters", String.join(", ", a, b));
+                    put(a + ".bootstrap.servers", clusterA.bootstrapServers());
+                    put(b + ".bootstrap.servers", clusterB.bootstrapServers());
+                    // Enable exactly-once support to both validate that MirrorMaker can run with
+                    // that feature turned on, and to force cross-worker communication before
+                    // task startup
+                    put(a + ".exactly.once.source.support", "enabled");
+                    put(b + ".exactly.once.source.support", "enabled");
+                    put(ab + ".enabled", "true");
+                    put(ba + ".enabled", "true");
+                    put(ab + ".topics", "^" + testTopicPrefix + ".*");
+                    put(ba + ".topics", "^" + testTopicPrefix + ".*");
+                    put("replication.factor", "1");
+                    put("checkpoints.topic.replication.factor", "1");
+                    put("heartbeats.topic.replication.factor", "1");
+                    put("offset-syncs.topic.replication.factor", "1");
+                    put("offset.storage.replication.factor", "1");
+                    put("status.storage.replication.factor", "1");
+                    put("config.storage.replication.factor", "1");
+                }};
+
+            // Bring up a three-node cluster
+            final int numNodes = 3;
+            for (int i = 0; i < numNodes; i++) {
+                startMirrorMaker("node " + i, mmProps);
+            }
+
+            // Create one topic per Kafka cluster per MirrorMaker node
+            final int topicsPerCluster = numNodes;
+            final int messagesPerTopic = 10;
+            for (int i = 0; i < topicsPerCluster; i++) {
+                String topic = testTopicPrefix + i;
+
+                // Create the topic on cluster A
+                createTopic(adminA, topic);
+                // and wait for MirrorMaker to create it on cluster B
+                awaitTopicCreation(b, adminB, a + "." + topic);
+
+                // Write data to the topic on cluster A
+                writeToTopic(clusterA, topic, messagesPerTopic);
+                // and wait for MirrorMaker to copy it to cluster B
+                awaitTopicContent(clusterB, b, a + "." + topic, messagesPerTopic);
+
+                // Do the same, but from cluster B to cluster A
+                createTopic(adminB, topic);
+                awaitTopicCreation(a, adminA, b + "." + topic);
+                writeToTopic(clusterB, topic, messagesPerTopic);
+                awaitTopicContent(clusterA, a, b + "." + topic, messagesPerTopic);
+            }
+        }
+    }
+
+    private void createTopic(Admin admin, String name) throws Exception {
+        admin.createTopics(Collections.singleton(new NewTopic(name, 1, (short) 1))).all().get();
+    }
+
+    private void awaitTopicCreation(String clusterName, Admin admin, String topic) throws Exception {
+        waitForCondition(
+                () -> {
+                    try {
+                        Set<String> allTopics = admin.listTopics().names().get();
+                        return allTopics.contains(topic);
+                    } catch (Exception e) {
+                        log.debug("Failed to check for existence of topic {} on cluster {}", topic, clusterName, e);
+                        return false;
+                    }
+                },
+                TOPIC_CREATION_TIMEOUT_MS,
+                "topic " + topic + " was not created on cluster " + clusterName + " in time"
+        );
+    }
+
+    private void writeToTopic(EmbeddedKafkaCluster cluster, String topic, int numMessages) {
+        for (int i = 0; i <= numMessages; i++) {
+            cluster.produce(topic, Integer.toString(i));
+        }
+    }
+
+    private void awaitTopicContent(EmbeddedKafkaCluster cluster, String clusterName, String topic, int numMessages) throws Exception {
+        try (Consumer<?, ?> consumer = cluster.createConsumer(Collections.singletonMap(AUTO_OFFSET_RESET_CONFIG, "earliest"))) {
+            consumer.subscribe(Collections.singleton(topic));
+            AtomicInteger messagesRead = new AtomicInteger(0);
+            waitForCondition(
+                    () -> {
+                        ConsumerRecords<?, ?> records = consumer.poll(Duration.ofSeconds(1));
+                        return messagesRead.addAndGet(records.count()) >= numMessages;
+                    },
+                    TOPIC_REPLICATION_TIMEOUT_MS,
+                    () -> "could not read " + numMessages + " from topic " + topic + " on cluster " + clusterName + " in time; only read " + messagesRead.get()
+            );
+        }
+    }
+
+}

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/DedicatedMirrorIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/DedicatedMirrorIntegrationTest.java
@@ -102,7 +102,6 @@ public class DedicatedMirrorIntegrationTest {
      * and reconfigure its connectors and their tasks to replicate those topics correctly.
      * See <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-710%3A+Full+support+for+distributed+mode+in+dedicated+MirrorMaker+2.0+clusters">KIP-710</a>
      * for more detail on the necessity for this test case.
-
      */
     @Test
     public void testMultiNodeCluster() throws Exception {
@@ -119,7 +118,6 @@ public class DedicatedMirrorIntegrationTest {
                 Admin adminB = clusterB.createAdminClient()) {
 
             // Cluster aliases
-            // Use weird names to ensure they're properly URL-encoded in cross-worker REST requests
             final String a = "A";
             final String b = "B";
             final String ab = a + "->" + b;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
@@ -28,7 +28,7 @@ import org.apache.kafka.connect.runtime.WorkerInfo;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.runtime.distributed.DistributedHerder;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
-import org.apache.kafka.connect.runtime.rest.RestServer;
+import org.apache.kafka.connect.runtime.rest.ConnectRestServer;
 import org.apache.kafka.connect.storage.ConfigBackingStore;
 import org.apache.kafka.connect.storage.Converter;
 import org.apache.kafka.connect.storage.KafkaConfigBackingStore;
@@ -99,7 +99,7 @@ public class ConnectDistributed {
         String kafkaClusterId = config.kafkaClusterId();
         log.debug("Kafka cluster ID: {}", kafkaClusterId);
 
-        RestServer rest = new RestServer(config);
+        ConnectRestServer rest = new ConnectRestServer(config.rebalanceTimeout(), workerProps);
         rest.initializeServer();
 
         URI advertisedUrl = rest.advertisedUrl();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
@@ -27,7 +27,7 @@ import org.apache.kafka.connect.runtime.Worker;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.WorkerInfo;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
-import org.apache.kafka.connect.runtime.rest.RestServer;
+import org.apache.kafka.connect.runtime.rest.ConnectRestServer;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
 import org.apache.kafka.connect.runtime.standalone.StandaloneHerder;
@@ -82,7 +82,7 @@ public class ConnectStandalone {
             String kafkaClusterId = config.kafkaClusterId();
             log.debug("Kafka cluster ID: {}", kafkaClusterId);
 
-            RestServer rest = new RestServer(config);
+            ConnectRestServer rest = new ConnectRestServer(null, workerProps);
             rest.initializeServer();
 
             URI advertisedUrl = rest.advertisedUrl();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Connect.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Connect.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.connect.runtime;
 
 import org.apache.kafka.common.utils.Exit;
+import org.apache.kafka.connect.runtime.rest.ConnectRestServer;
 import org.apache.kafka.connect.runtime.rest.RestServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,13 +33,13 @@ public class Connect {
     private static final Logger log = LoggerFactory.getLogger(Connect.class);
 
     private final Herder herder;
-    private final RestServer rest;
+    private final ConnectRestServer rest;
     private final CountDownLatch startLatch = new CountDownLatch(1);
     private final CountDownLatch stopLatch = new CountDownLatch(1);
     private final AtomicBoolean shutdown = new AtomicBoolean(false);
     private final ShutdownHook shutdownHook;
 
-    public Connect(Herder herder, RestServer rest) {
+    public Connect(Herder herder, ConnectRestServer rest) {
         log.debug("Kafka Connect instance created");
         this.herder = herder;
         this.rest = rest;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -24,27 +24,21 @@ import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
-import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.common.config.SslClientAuth;
-import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.runtime.rest.RestServerConfig;
 import org.apache.kafka.connect.storage.SimpleHeaderConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
-
-import org.eclipse.jetty.util.StringUtil;
 
 import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
 import static org.apache.kafka.common.config.ConfigDef.ValidString.in;
@@ -57,9 +51,6 @@ public class WorkerConfig extends AbstractConfig {
     private static final Logger log = LoggerFactory.getLogger(WorkerConfig.class);
 
     private static final Pattern COMMA_WITH_WHITESPACE = Pattern.compile("\\s*,\\s*");
-    private static final Collection<String> HEADER_ACTIONS = Collections.unmodifiableList(
-            Arrays.asList("set", "add", "setDate", "addDate")
-    );
 
     public static final String BOOTSTRAP_SERVERS_CONFIG = "bootstrap.servers";
     public static final String BOOTSTRAP_SERVERS_DOC
@@ -119,47 +110,6 @@ public class WorkerConfig extends AbstractConfig {
             + "running with exactly-once support.";
     public static final long OFFSET_COMMIT_TIMEOUT_MS_DEFAULT = 5000L;
 
-    public static final String LISTENERS_CONFIG = "listeners";
-    private static final String LISTENERS_DOC
-            = "List of comma-separated URIs the REST API will listen on. The supported protocols are HTTP and HTTPS.\n" +
-            " Specify hostname as 0.0.0.0 to bind to all interfaces.\n" +
-            " Leave hostname empty to bind to default interface.\n" +
-            " Examples of legal listener lists: HTTP://myhost:8083,HTTPS://myhost:8084";
-    static final List<String> LISTENERS_DEFAULT = Collections.singletonList("http://:8083");
-
-    public static final String REST_ADVERTISED_HOST_NAME_CONFIG = "rest.advertised.host.name";
-    private static final String REST_ADVERTISED_HOST_NAME_DOC
-            = "If this is set, this is the hostname that will be given out to other workers to connect to.";
-
-    public static final String REST_ADVERTISED_PORT_CONFIG = "rest.advertised.port";
-    private static final String REST_ADVERTISED_PORT_DOC
-            = "If this is set, this is the port that will be given out to other workers to connect to.";
-
-    public static final String REST_ADVERTISED_LISTENER_CONFIG = "rest.advertised.listener";
-    private static final String REST_ADVERTISED_LISTENER_DOC
-            = "Sets the advertised listener (HTTP or HTTPS) which will be given to other workers to use.";
-
-    public static final String ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG = "access.control.allow.origin";
-    protected static final String ACCESS_CONTROL_ALLOW_ORIGIN_DOC =
-            "Value to set the Access-Control-Allow-Origin header to for REST API requests." +
-                    "To enable cross origin access, set this to the domain of the application that should be permitted" +
-                    " to access the API, or '*' to allow access from any domain. The default value only allows access" +
-                    " from the domain of the REST API.";
-    protected static final String ACCESS_CONTROL_ALLOW_ORIGIN_DEFAULT = "";
-
-    public static final String ACCESS_CONTROL_ALLOW_METHODS_CONFIG = "access.control.allow.methods";
-    protected static final String ACCESS_CONTROL_ALLOW_METHODS_DOC =
-        "Sets the methods supported for cross origin requests by setting the Access-Control-Allow-Methods header. "
-        + "The default value of the Access-Control-Allow-Methods header allows cross origin requests for GET, POST and HEAD.";
-    protected static final String ACCESS_CONTROL_ALLOW_METHODS_DEFAULT = "";
-
-    public static final String ADMIN_LISTENERS_CONFIG = "admin.listeners";
-    protected static final String ADMIN_LISTENERS_DOC = "List of comma-separated URIs the Admin REST API will listen on." +
-            " The supported protocols are HTTP and HTTPS." +
-            " An empty or blank string will disable this feature." +
-            " The default behavior is to use the regular listener (specified by the 'listeners' property).";
-    public static final String ADMIN_LISTENERS_HTTPS_CONFIGS_PREFIX = "admin.listeners.https.";
-
     public static final String PLUGIN_PATH_CONFIG = "plugin.path";
     protected static final String PLUGIN_PATH_DOC = "List of paths separated by commas (,) that "
             + "contain plugins (connectors, converters, transformations). The list should consist"
@@ -181,13 +131,6 @@ public class WorkerConfig extends AbstractConfig {
             + "in the order specified. Implementing the interface  "
             + "<code>ConfigProvider</code> allows you to replace variable references in connector configurations, "
             + "such as for externalized secrets. ";
-
-    public static final String REST_EXTENSION_CLASSES_CONFIG = "rest.extension.classes";
-    protected static final String REST_EXTENSION_CLASSES_DOC =
-            "Comma-separated names of <code>ConnectRestExtension</code> classes, loaded and called "
-            + "in the order specified. Implementing the interface  "
-            + "<code>ConnectRestExtension</code> allows you to inject into Connect's REST API user defined resources like filters. "
-            + "Typically used to add custom capability like logging, security, etc. ";
 
     public static final String CONNECTOR_CLIENT_POLICY_CLASS_CONFIG = "connector.client.config.override.policy";
     public static final String CONNECTOR_CLIENT_POLICY_CLASS_DOC =
@@ -227,17 +170,13 @@ public class WorkerConfig extends AbstractConfig {
             + "to create topics automatically.";
     protected static final boolean TOPIC_CREATION_ENABLE_DEFAULT = true;
 
-    public static final String RESPONSE_HTTP_HEADERS_CONFIG = "response.http.headers.config";
-    protected static final String RESPONSE_HTTP_HEADERS_DOC = "Rules for REST API HTTP response headers";
-    protected static final String RESPONSE_HTTP_HEADERS_DEFAULT = "";
-
     /**
      * Get a basic ConfigDef for a WorkerConfig. This includes all the common settings. Subclasses can use this to
      * bootstrap their own ConfigDef.
      * @return a ConfigDef with all the common options specified
      */
     protected static ConfigDef baseConfigDef() {
-        return new ConfigDef()
+        ConfigDef result = new ConfigDef()
                 .define(BOOTSTRAP_SERVERS_CONFIG, Type.LIST, BOOTSTRAP_SERVERS_DEFAULT,
                         Importance.HIGH, BOOTSTRAP_SERVERS_DOC)
                 .define(CLIENT_DNS_LOOKUP_CONFIG,
@@ -258,16 +197,6 @@ public class WorkerConfig extends AbstractConfig {
                         Importance.LOW, OFFSET_COMMIT_INTERVAL_MS_DOC)
                 .define(OFFSET_COMMIT_TIMEOUT_MS_CONFIG, Type.LONG, OFFSET_COMMIT_TIMEOUT_MS_DEFAULT,
                         Importance.LOW, OFFSET_COMMIT_TIMEOUT_MS_DOC)
-                .define(LISTENERS_CONFIG, Type.LIST, LISTENERS_DEFAULT, new ListenersValidator(), Importance.LOW, LISTENERS_DOC)
-                .define(REST_ADVERTISED_HOST_NAME_CONFIG, Type.STRING,  null, Importance.LOW, REST_ADVERTISED_HOST_NAME_DOC)
-                .define(REST_ADVERTISED_PORT_CONFIG, Type.INT,  null, Importance.LOW, REST_ADVERTISED_PORT_DOC)
-                .define(REST_ADVERTISED_LISTENER_CONFIG, Type.STRING,  null, Importance.LOW, REST_ADVERTISED_LISTENER_DOC)
-                .define(ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG, Type.STRING,
-                        ACCESS_CONTROL_ALLOW_ORIGIN_DEFAULT, Importance.LOW,
-                        ACCESS_CONTROL_ALLOW_ORIGIN_DOC)
-                .define(ACCESS_CONTROL_ALLOW_METHODS_CONFIG, Type.STRING,
-                        ACCESS_CONTROL_ALLOW_METHODS_DEFAULT, Importance.LOW,
-                        ACCESS_CONTROL_ALLOW_METHODS_DOC)
                 .define(PLUGIN_PATH_CONFIG,
                         Type.LIST,
                         null,
@@ -292,30 +221,37 @@ public class WorkerConfig extends AbstractConfig {
                         true,
                         Importance.LOW,
                         CommonClientConfigs.AUTO_INCLUDE_JMX_REPORTER_DOC)
-                .define(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG,
-                        ConfigDef.Type.STRING, SslClientAuth.NONE.toString(), in(Utils.enumOptions(SslClientAuth.class)), ConfigDef.Importance.LOW, BrokerSecurityConfigs.SSL_CLIENT_AUTH_DOC)
                 .define(HEADER_CONVERTER_CLASS_CONFIG, Type.CLASS,
                         HEADER_CONVERTER_CLASS_DEFAULT,
                         Importance.LOW, HEADER_CONVERTER_CLASS_DOC)
                 .define(CONFIG_PROVIDERS_CONFIG, Type.LIST,
                         Collections.emptyList(),
                         Importance.LOW, CONFIG_PROVIDERS_DOC)
-                .define(REST_EXTENSION_CLASSES_CONFIG, Type.LIST, "",
-                        Importance.LOW, REST_EXTENSION_CLASSES_DOC)
-                .define(ADMIN_LISTENERS_CONFIG, Type.LIST, null,
-                        new AdminListenersValidator(), Importance.LOW, ADMIN_LISTENERS_DOC)
                 .define(CONNECTOR_CLIENT_POLICY_CLASS_CONFIG, Type.STRING, CONNECTOR_CLIENT_POLICY_CLASS_DEFAULT,
                         Importance.MEDIUM, CONNECTOR_CLIENT_POLICY_CLASS_DOC)
-                .define(TOPIC_TRACKING_ENABLE_CONFIG, Type.BOOLEAN, TOPIC_TRACKING_ENABLE_DEFAULT,
-                        Importance.LOW, TOPIC_TRACKING_ENABLE_DOC)
-                .define(TOPIC_TRACKING_ALLOW_RESET_CONFIG, Type.BOOLEAN, TOPIC_TRACKING_ALLOW_RESET_DEFAULT,
-                        Importance.LOW, TOPIC_TRACKING_ALLOW_RESET_DOC)
                 .define(TOPIC_CREATION_ENABLE_CONFIG, Type.BOOLEAN, TOPIC_CREATION_ENABLE_DEFAULT, Importance.LOW,
                         TOPIC_CREATION_ENABLE_DOC)
-                .define(RESPONSE_HTTP_HEADERS_CONFIG, Type.STRING, RESPONSE_HTTP_HEADERS_DEFAULT,
-                        new ResponseHttpHeadersValidator(), Importance.LOW, RESPONSE_HTTP_HEADERS_DOC)
                 // security support
                 .withClientSslSupport();
+        addTopicTrackingConfig(result);
+        RestServerConfig.addPublicConfig(result);
+        return result;
+    }
+
+    public static void addTopicTrackingConfig(ConfigDef configDef) {
+        configDef
+                .define(
+                        TOPIC_TRACKING_ENABLE_CONFIG,
+                        ConfigDef.Type.BOOLEAN,
+                        TOPIC_TRACKING_ENABLE_DEFAULT,
+                        ConfigDef.Importance.LOW,
+                        TOPIC_TRACKING_ENABLE_DOC
+                ).define(
+                        TOPIC_TRACKING_ALLOW_RESET_CONFIG,
+                        ConfigDef.Type.BOOLEAN,
+                        TOPIC_TRACKING_ALLOW_RESET_DEFAULT,
+                        ConfigDef.Importance.LOW,
+                        TOPIC_TRACKING_ALLOW_RESET_DOC);
     }
 
     private String kafkaClusterId;
@@ -392,10 +328,6 @@ public class WorkerConfig extends AbstractConfig {
      */
     public String bootstrapServers() {
         return String.join(",", getList(BOOTSTRAP_SERVERS_CONFIG));
-    }
-
-    public Integer getRebalanceTimeout() {
-        return null;
     }
 
     public boolean topicCreationEnable() {
@@ -475,125 +407,4 @@ public class WorkerConfig extends AbstractConfig {
         logPluginPathConfigProviderWarning(props);
     }
 
-    // Visible for testing
-    static void validateHttpResponseHeaderConfig(String config) {
-        try {
-            // validate format
-            String[] configTokens = config.trim().split("\\s+", 2);
-            if (configTokens.length != 2) {
-                throw new ConfigException(String.format("Invalid format of header config '%s'. "
-                        + "Expected: '[action] [header name]:[header value]'", config));
-            }
-
-            // validate action
-            String method = configTokens[0].trim();
-            validateHeaderConfigAction(method);
-
-            // validate header name and header value pair
-            String header = configTokens[1];
-            String[] headerTokens = header.trim().split(":");
-            if (headerTokens.length != 2) {
-                throw new ConfigException(
-                        String.format("Invalid format of header name and header value pair '%s'. "
-                                + "Expected: '[header name]:[header value]'", header));
-            }
-
-            // validate header name
-            String headerName = headerTokens[0].trim();
-            if (headerName.isEmpty() || headerName.matches(".*\\s+.*")) {
-                throw new ConfigException(String.format("Invalid header name '%s'. "
-                        + "The '[header name]' cannot contain whitespace", headerName));
-            }
-        } catch (ArrayIndexOutOfBoundsException e) {
-            throw new ConfigException(String.format("Invalid header config '%s'.", config), e);
-        }
-    }
-
-    // Visible for testing
-    static void validateHeaderConfigAction(String action) {
-        if (HEADER_ACTIONS.stream().noneMatch(action::equalsIgnoreCase)) {
-            throw new ConfigException(String.format("Invalid header config action: '%s'. "
-                    + "Expected one of %s", action, HEADER_ACTIONS));
-        }
-    }
-
-    private static class ListenersValidator implements ConfigDef.Validator {
-        @Override
-        public void ensureValid(String name, Object value) {
-            if (!(value instanceof List)) {
-                throw new ConfigException("Invalid value type for listeners (expected list of URLs , ex: http://localhost:8080,https://localhost:8443).");
-            }
-
-            List<?> items = (List<?>) value;
-            if (items.isEmpty()) {
-                throw new ConfigException("Invalid value for listeners, at least one URL is expected, ex: http://localhost:8080,https://localhost:8443.");
-            }
-
-            for (Object item : items) {
-                if (!(item instanceof String)) {
-                    throw new ConfigException("Invalid type for listeners (expected String).");
-                }
-                if (Utils.isBlank((String) item)) {
-                    throw new ConfigException("Empty URL found when parsing listeners list.");
-                }
-            }
-        }
-
-        @Override
-        public String toString() {
-            return "List of comma-separated URLs, ex: http://localhost:8080,https://localhost:8443.";
-        }
-    }
-
-    private static class AdminListenersValidator implements ConfigDef.Validator {
-        @Override
-        public void ensureValid(String name, Object value) {
-            if (value == null) {
-                return;
-            }
-
-            if (!(value instanceof List)) {
-                throw new ConfigException("Invalid value type for admin.listeners (expected list).");
-            }
-
-            List<?> items = (List<?>) value;
-            if (items.isEmpty()) {
-                return;
-            }
-
-            for (Object item : items) {
-                if (!(item instanceof String)) {
-                    throw new ConfigException("Invalid type for admin.listeners (expected String).");
-                }
-                if (Utils.isBlank((String) item)) {
-                    throw new ConfigException("Empty URL found when parsing admin.listeners list.");
-                }
-            }
-        }
-
-        @Override
-        public String toString() {
-            return "List of comma-separated URLs, ex: http://localhost:8080,https://localhost:8443.";
-        }
-    }
-
-    private static class ResponseHttpHeadersValidator implements ConfigDef.Validator {
-        @Override
-        public void ensureValid(String name, Object value) {
-            String strValue = (String) value;
-            if (Utils.isBlank(strValue)) {
-                return;
-            }
-
-            String[] configs = StringUtil.csvSplit(strValue); // handles and removed surrounding quotes
-            Arrays.stream(configs).forEach(WorkerConfig::validateHttpResponseHeaderConfig);
-        }
-
-        @Override
-        public String toString() {
-            return "Comma-separated header rules, where each header rule is of the form "
-                    + "'[action] [header name]:[header value]' and optionally surrounded by double quotes "
-                    + "if any part of a header rule contains a comma";
-        }
-    }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
@@ -500,8 +500,7 @@ public class DistributedConfig extends WorkerConfig {
 
     private final ExactlyOnceSourceSupport exactlyOnceSourceSupport;
 
-    @Override
-    public Integer getRebalanceTimeout() {
+    public Integer rebalanceTimeout() {
         return getInt(DistributedConfig.REBALANCE_TIMEOUT_MS_CONFIG);
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/ConnectRestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/ConnectRestServer.java
@@ -20,6 +20,7 @@ import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.rest.resources.ConnectResource;
 import org.apache.kafka.connect.runtime.rest.resources.ConnectorPluginsResource;
 import org.apache.kafka.connect.runtime.rest.resources.ConnectorsResource;
+import org.apache.kafka.connect.runtime.rest.resources.InternalConnectResource;
 import org.apache.kafka.connect.runtime.rest.resources.LoggingResource;
 import org.apache.kafka.connect.runtime.rest.resources.RootResource;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -46,6 +47,7 @@ public class ConnectRestServer extends RestServer {
         return Arrays.asList(
                 new RootResource(herder),
                 new ConnectorsResource(herder, config),
+                new InternalConnectResource(herder, config),
                 new ConnectorPluginsResource(herder)
         );
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/ConnectRestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/ConnectRestServer.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.rest;
+
+import org.apache.kafka.connect.runtime.Herder;
+import org.apache.kafka.connect.runtime.rest.resources.ConnectResource;
+import org.apache.kafka.connect.runtime.rest.resources.ConnectorPluginsResource;
+import org.apache.kafka.connect.runtime.rest.resources.ConnectorsResource;
+import org.apache.kafka.connect.runtime.rest.resources.LoggingResource;
+import org.apache.kafka.connect.runtime.rest.resources.RootResource;
+import org.glassfish.jersey.server.ResourceConfig;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+public class ConnectRestServer extends RestServer {
+
+    private Herder herder;
+
+    public ConnectRestServer(Integer rebalanceTimeoutMs, Map<?, ?> props) {
+        super(RestServerConfig.forPublic(rebalanceTimeoutMs, props));
+    }
+
+    public void initializeResources(Herder herder) {
+        this.herder = herder;
+        super.initializeResources();
+    }
+
+    @Override
+    protected Collection<ConnectResource> regularResources() {
+        return Arrays.asList(
+                new RootResource(herder),
+                new ConnectorsResource(herder, config),
+                new ConnectorPluginsResource(herder)
+        );
+    }
+
+    @Override
+    protected Collection<ConnectResource> adminResources() {
+        return Arrays.asList(
+                new LoggingResource()
+        );
+    }
+
+    @Override
+    protected void configureRegularResources(ResourceConfig resourceConfig) {
+        registerRestExtensions(herder, resourceConfig);
+    }
+
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/HerderRequestHandler.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/HerderRequestHandler.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.rest;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.connect.runtime.distributed.RebalanceNeededException;
+import org.apache.kafka.connect.runtime.distributed.RequestTargetException;
+import org.apache.kafka.connect.runtime.rest.errors.ConnectRestException;
+import org.apache.kafka.connect.util.FutureCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class HerderRequestHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(HerderRequestHandler.class);
+
+    private final AbstractConfig serverConfig;
+
+    private long requestTimeoutMs;
+
+    public HerderRequestHandler(AbstractConfig serverConfig, long requestTimeoutMs) {
+        this.serverConfig = serverConfig;
+        this.requestTimeoutMs = requestTimeoutMs;
+    }
+
+    public void requestTimeoutMs(long requestTimeoutMs) {
+        if (requestTimeoutMs < 1) {
+            throw new IllegalArgumentException("REST request timeout must be positive");
+        }
+        this.requestTimeoutMs = requestTimeoutMs;
+    }
+
+    /**
+     * Wait for a FutureCallback to complete. If it succeeds, return the parsed response. If it fails, try to forward the
+     * request to the leader.
+      */
+    public <T, U> T completeOrForwardRequest(FutureCallback<T> cb,
+                                                    String path,
+                                                    String method,
+                                                    HttpHeaders headers,
+                                                    Map<String, String> queryParameters,
+                                                    Object body,
+                                                    TypeReference<U> resultType,
+                                                    Translator<T, U> translator,
+                                                    Boolean forward) throws Throwable {
+        try {
+            return cb.get(requestTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+
+            if (cause instanceof RequestTargetException) {
+                if (forward == null || forward) {
+                    // the only time we allow recursive forwarding is when no forward flag has
+                    // been set, which should only be seen by the first worker to handle a user request.
+                    // this gives two total hops to resolve the request before giving up.
+                    boolean recursiveForward = forward == null;
+                    RequestTargetException targetException = (RequestTargetException) cause;
+                    String forwardedUrl = targetException.forwardUrl();
+                    if (forwardedUrl == null) {
+                        // the target didn't know of the leader at this moment.
+                        throw new ConnectRestException(Response.Status.CONFLICT.getStatusCode(),
+                                "Cannot complete request momentarily due to no known leader URL, "
+                                        + "likely because a rebalance was underway.");
+                    }
+                    UriBuilder uriBuilder = UriBuilder.fromUri(forwardedUrl)
+                            .path(path)
+                            .queryParam("forward", recursiveForward);
+                    if (queryParameters != null) {
+                        queryParameters.forEach(uriBuilder::queryParam);
+                    }
+                    String forwardUrl = uriBuilder.build().toString();
+                    log.debug("Forwarding request {} {} {}", forwardUrl, method, body);
+                    return translator.translate(RestClient.httpRequest(forwardUrl, method, headers, body, resultType, serverConfig));
+                } else {
+                    // we should find the right target for the query within two hops, so if
+                    // we don't, it probably means that a rebalance has taken place.
+                    throw new ConnectRestException(Response.Status.CONFLICT.getStatusCode(),
+                            "Cannot complete request because of a conflicting operation (e.g. worker rebalance)");
+                }
+            } else if (cause instanceof RebalanceNeededException) {
+                throw new ConnectRestException(Response.Status.CONFLICT.getStatusCode(),
+                        "Cannot complete request momentarily due to stale configuration (typically caused by a concurrent config change)");
+            }
+
+            throw cause;
+        } catch (TimeoutException e) {
+            // This timeout is for the operation itself. None of the timeout error codes are relevant, so internal server
+            // error is the best option
+            throw new ConnectRestException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), "Request timed out");
+        } catch (InterruptedException e) {
+            throw new ConnectRestException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), "Request interrupted");
+        }
+    }
+
+    public <T, U> T completeOrForwardRequest(FutureCallback<T> cb, String path, String method, HttpHeaders headers, Object body,
+                                             TypeReference<U> resultType, Translator<T, U> translator, Boolean forward) throws Throwable {
+        return completeOrForwardRequest(cb, path, method, headers, null, body, resultType, translator, forward);
+    }
+
+    public <T> T completeOrForwardRequest(FutureCallback<T> cb, String path, String method, HttpHeaders headers, Object body,
+                                                 TypeReference<T> resultType, Boolean forward) throws Throwable {
+        return completeOrForwardRequest(cb, path, method, headers, body, resultType, new IdentityTranslator<>(), forward);
+    }
+
+    public <T> T completeOrForwardRequest(FutureCallback<T> cb, String path, String method, HttpHeaders headers,
+                                                 Object body, Boolean forward) throws Throwable {
+        return completeOrForwardRequest(cb, path, method, headers, body, null, new IdentityTranslator<>(), forward);
+    }
+
+    public interface Translator<T, U> {
+        T translate(RestClient.HttpResponse<U> response);
+    }
+
+    public static class IdentityTranslator<T> implements Translator<T, T> {
+        @Override
+        public T translate(RestClient.HttpResponse<T> response) {
+            return response.body();
+        }
+    }
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java
@@ -19,7 +19,7 @@ package org.apache.kafka.connect.runtime.rest;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.kafka.connect.runtime.WorkerConfig;
+import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.runtime.rest.entities.ErrorMessage;
 import org.apache.kafka.connect.runtime.rest.errors.ConnectRestException;
 import org.apache.kafka.connect.runtime.rest.util.SSLUtils;
@@ -59,7 +59,7 @@ public class RestClient {
      * @return The deserialized response to the HTTP request, or null if no data is expected.
      */
     public static <T> HttpResponse<T> httpRequest(String url, String method, HttpHeaders headers, Object requestBodyData,
-                                                  TypeReference<T> responseFormat, WorkerConfig config) {
+                                                  TypeReference<T> responseFormat, AbstractConfig config) {
         return httpRequest(url, method, headers, requestBodyData, responseFormat, config, null, null);
     }
 
@@ -79,7 +79,7 @@ public class RestClient {
      * @return The deserialized response to the HTTP request, or null if no data is expected.
      */
     public static <T> HttpResponse<T> httpRequest(String url, String method, HttpHeaders headers, Object requestBodyData,
-                                                  TypeReference<T> responseFormat, WorkerConfig config,
+                                                  TypeReference<T> responseFormat, AbstractConfig config,
                                                   SecretKey sessionKey, String requestSignatureAlgorithm) {
         HttpClient client;
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -24,15 +24,10 @@ import org.apache.kafka.connect.health.ConnectClusterDetails;
 import org.apache.kafka.connect.rest.ConnectRestExtension;
 import org.apache.kafka.connect.rest.ConnectRestExtensionContext;
 import org.apache.kafka.connect.runtime.Herder;
-import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.health.ConnectClusterDetailsImpl;
 import org.apache.kafka.connect.runtime.health.ConnectClusterStateImpl;
 import org.apache.kafka.connect.runtime.rest.errors.ConnectExceptionMapper;
 import org.apache.kafka.connect.runtime.rest.resources.ConnectResource;
-import org.apache.kafka.connect.runtime.rest.resources.ConnectorPluginsResource;
-import org.apache.kafka.connect.runtime.rest.resources.ConnectorsResource;
-import org.apache.kafka.connect.runtime.rest.resources.LoggingResource;
-import org.apache.kafka.connect.runtime.rest.resources.RootResource;
 import org.apache.kafka.connect.runtime.rest.util.SSLUtils;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.CustomRequestLog;
@@ -67,12 +62,10 @@ import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.apache.kafka.connect.runtime.WorkerConfig.ADMIN_LISTENERS_HTTPS_CONFIGS_PREFIX;
-
 /**
  * Embedded server for the REST API that provides the control plane for Kafka Connect workers.
  */
-public class RestServer {
+public abstract class RestServer {
     private static final Logger log = LoggerFactory.getLogger(RestServer.class);
 
     // Used to distinguish between Admin connectors and regular REST API connectors when binding admin handlers
@@ -84,7 +77,7 @@ public class RestServer {
     private static final String PROTOCOL_HTTP = "http";
     private static final String PROTOCOL_HTTPS = "https";
 
-    private final WorkerConfig config;
+    protected final RestServerConfig config;
     private final ContextHandlerCollection handlers;
     private final Server jettyServer;
 
@@ -94,11 +87,11 @@ public class RestServer {
     /**
      * Create a REST server for this herder using the specified configs.
      */
-    public RestServer(WorkerConfig config) {
+    protected RestServer(RestServerConfig config) {
         this.config = config;
 
-        List<String> listeners = config.getList(WorkerConfig.LISTENERS_CONFIG);
-        List<String> adminListeners = config.getList(WorkerConfig.ADMIN_LISTENERS_CONFIG);
+        List<String> listeners = config.listeners();
+        List<String> adminListeners = config.adminListeners();
 
         jettyServer = new Server();
         handlers = new ContextHandlerCollection();
@@ -158,7 +151,7 @@ public class RestServer {
         if (PROTOCOL_HTTPS.equals(protocol)) {
             SslContextFactory ssl;
             if (isAdmin) {
-                ssl = SSLUtils.createServerSideSslContextFactory(config, ADMIN_LISTENERS_HTTPS_CONFIGS_PREFIX);
+                ssl = SSLUtils.createServerSideSslContextFactory(config, RestServerConfig.ADMIN_LISTENERS_HTTPS_CONFIGS_PREFIX);
             } else {
                 ssl = SSLUtils.createServerSideSslContextFactory(config);
             }
@@ -207,43 +200,44 @@ public class RestServer {
         }
 
         log.info("REST server listening at " + jettyServer.getURI() + ", advertising URL " + advertisedUrl());
-        log.info("REST admin endpoints at " + adminUrl());
+        URI adminUrl = adminUrl();
+        if (adminUrl != null)
+            log.info("REST admin endpoints at " + adminUrl);
     }
 
-    public void initializeResources(Herder herder) {
+    protected final void initializeResources() {
         log.info("Initializing REST resources");
+        this.resources = new ArrayList<>();
 
         ResourceConfig resourceConfig = new ResourceConfig();
         resourceConfig.register(new JacksonJsonProvider());
 
-        this.resources = new ArrayList<>();
-        resources.add(new RootResource(herder));
-        resources.add(new ConnectorsResource(herder, config));
-        resources.add(new ConnectorPluginsResource(herder));
-        resources.forEach(resourceConfig::register);
+        Collection<ConnectResource> regularResources = regularResources();
+        regularResources.forEach(resourceConfig::register);
+        resources.addAll(regularResources);
 
         resourceConfig.register(ConnectExceptionMapper.class);
         resourceConfig.property(ServerProperties.WADL_FEATURE_DISABLE, true);
 
-        registerRestExtensions(herder, resourceConfig);
+        configureRegularResources(resourceConfig);
 
-        List<String> adminListeners = config.getList(WorkerConfig.ADMIN_LISTENERS_CONFIG);
+        List<String> adminListeners = config.adminListeners();
         ResourceConfig adminResourceConfig;
         if (adminListeners == null) {
             log.info("Adding admin resources to main listener");
             adminResourceConfig = resourceConfig;
-            LoggingResource loggingResource = new LoggingResource();
-            this.resources.add(loggingResource);
-            adminResourceConfig.register(loggingResource);
+            Collection<ConnectResource> adminResources = adminResources();
+            resources.addAll(adminResources);
+            adminResources.forEach(adminResourceConfig::register);
         } else if (adminListeners.size() > 0) {
             // TODO: we need to check if these listeners are same as 'listeners'
             // TODO: the following code assumes that they are different
             log.info("Adding admin resources to admin listener");
             adminResourceConfig = new ResourceConfig();
             adminResourceConfig.register(new JacksonJsonProvider());
-            LoggingResource loggingResource = new LoggingResource();
-            this.resources.add(loggingResource);
-            adminResourceConfig.register(loggingResource);
+            Collection<ConnectResource> adminResources = adminResources();
+            resources.addAll(adminResources);
+            adminResources.forEach(adminResourceConfig::register);
             adminResourceConfig.register(ConnectExceptionMapper.class);
         } else {
             log.info("Skipping adding admin resources");
@@ -270,21 +264,21 @@ public class RestServer {
             contextHandlers.add(adminContext);
         }
 
-        String allowedOrigins = config.getString(WorkerConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG);
+        String allowedOrigins = config.allowedOrigins();
         if (!Utils.isBlank(allowedOrigins)) {
             FilterHolder filterHolder = new FilterHolder(new CrossOriginFilter());
             filterHolder.setName("cross-origin");
             filterHolder.setInitParameter(CrossOriginFilter.ALLOWED_ORIGINS_PARAM, allowedOrigins);
-            String allowedMethods = config.getString(WorkerConfig.ACCESS_CONTROL_ALLOW_METHODS_CONFIG);
+            String allowedMethods = config.allowedMethods();
             if (!Utils.isBlank(allowedMethods)) {
                 filterHolder.setInitParameter(CrossOriginFilter.ALLOWED_METHODS_PARAM, allowedMethods);
             }
             context.addFilter(filterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
         }
 
-        String headerConfig = config.getString(WorkerConfig.RESPONSE_HTTP_HEADERS_CONFIG);
+        String headerConfig = config.responseHeaders();
         if (!Utils.isBlank(headerConfig)) {
-            configureHttpResponsHeaderFilter(context);
+            configureHttpResponsHeaderFilter(context, headerConfig);
         }
 
         handlers.setHandlers(contextHandlers.toArray(new Handler[0]));
@@ -304,6 +298,18 @@ public class RestServer {
         }
 
         log.info("REST resources initialized; server is started and ready to handle requests");
+    }
+
+    protected abstract Collection<ConnectResource> regularResources();
+
+    protected abstract Collection<ConnectResource> adminResources();
+
+    protected void configureRegularResources(ResourceConfig resourceConfig) {
+        // No-op by default
+    }
+
+    protected void configureAdminResources(ResourceConfig adminResourceConfig) {
+        // No-op by default
     }
 
     public URI serverUrl() {
@@ -343,13 +349,13 @@ public class RestServer {
         ServerConnector serverConnector = findConnector(advertisedSecurityProtocol);
         builder.scheme(advertisedSecurityProtocol);
 
-        String advertisedHostname = config.getString(WorkerConfig.REST_ADVERTISED_HOST_NAME_CONFIG);
+        String advertisedHostname = config.advertisedHostName();
         if (advertisedHostname != null && !advertisedHostname.isEmpty())
             builder.host(advertisedHostname);
         else if (serverConnector != null && serverConnector.getHost() != null && serverConnector.getHost().length() > 0)
             builder.host(serverConnector.getHost());
 
-        Integer advertisedPort = config.getInt(WorkerConfig.REST_ADVERTISED_PORT_CONFIG);
+        Integer advertisedPort = config.advertisedPort();
         if (advertisedPort != null)
             builder.port(advertisedPort);
         else if (serverConnector != null && serverConnector.getPort() > 0)
@@ -371,7 +377,7 @@ public class RestServer {
         }
 
         if (adminConnector == null) {
-            List<String> adminListeners = config.getList(WorkerConfig.ADMIN_LISTENERS_CONFIG);
+            List<String> adminListeners = config.adminListeners();
             if (adminListeners == null) {
                 return advertisedUrl();
             } else if (adminListeners.isEmpty()) {
@@ -394,9 +400,9 @@ public class RestServer {
     }
 
     String determineAdvertisedProtocol() {
-        String advertisedSecurityProtocol = config.getString(WorkerConfig.REST_ADVERTISED_LISTENER_CONFIG);
+        String advertisedSecurityProtocol = config.advertisedListener();
         if (advertisedSecurityProtocol == null) {
-            String listeners = (String) config.originals().get(WorkerConfig.LISTENERS_CONFIG);
+            String listeners = config.rawListeners();
 
             if (listeners == null)
                 return PROTOCOL_HTTP;
@@ -435,14 +441,14 @@ public class RestServer {
         return null;
     }
 
-    void registerRestExtensions(Herder herder, ResourceConfig resourceConfig) {
+    protected final void registerRestExtensions(Herder herder, ResourceConfig resourceConfig) {
         connectRestExtensions = herder.plugins().newPlugins(
-            config.getList(WorkerConfig.REST_EXTENSION_CLASSES_CONFIG),
+            config.restExtensions(),
             config, ConnectRestExtension.class);
 
         long herderRequestTimeoutMs = ConnectResource.DEFAULT_REST_REQUEST_TIMEOUT_MS;
 
-        Integer rebalanceTimeoutMs = config.getRebalanceTimeout();
+        Integer rebalanceTimeoutMs = config.rebalanceTimeoutMs();
 
         if (rebalanceTimeoutMs != null) {
             herderRequestTimeoutMs = Math.min(herderRequestTimeoutMs, rebalanceTimeoutMs.longValue());
@@ -467,8 +473,7 @@ public class RestServer {
      * Register header filter to ServletContextHandler.
      * @param context The serverlet context handler
      */
-    protected void configureHttpResponsHeaderFilter(ServletContextHandler context) {
-        String headerConfig = config.getString(WorkerConfig.RESPONSE_HTTP_HEADERS_CONFIG);
+    protected void configureHttpResponsHeaderFilter(ServletContextHandler context, String headerConfig) {
         FilterHolder headerFilterHolder = new FilterHolder(HeaderFilter.class);
         headerFilterHolder.setInitParameter("headerConfig", headerConfig);
         context.addFilter(headerFilterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -229,6 +229,7 @@ public abstract class RestServer {
             Collection<ConnectResource> adminResources = adminResources();
             resources.addAll(adminResources);
             adminResources.forEach(adminResourceConfig::register);
+            configureAdminResources(adminResourceConfig);
         } else if (adminListeners.size() > 0) {
             // TODO: we need to check if these listeners are same as 'listeners'
             // TODO: the following code assumes that they are different
@@ -239,6 +240,7 @@ public abstract class RestServer {
             resources.addAll(adminResources);
             adminResources.forEach(adminResourceConfig::register);
             adminResourceConfig.register(ConnectExceptionMapper.class);
+            configureAdminResources(adminResourceConfig);
         } else {
             log.info("Skipping adding admin resources");
             // set up adminResource but add no handlers to it
@@ -300,14 +302,40 @@ public abstract class RestServer {
         log.info("REST resources initialized; server is started and ready to handle requests");
     }
 
+    /**
+     * @return the {@link ConnectResource resources} that should be registered with the
+     * standard (i.e., non-admin) listener for this server; may be empty, but not null
+     */
     protected abstract Collection<ConnectResource> regularResources();
 
+    /**
+     * @return the {@link ConnectResource resources} that should be registered with the
+     * admin listener for this server; may be empty, but not null
+     */
     protected abstract Collection<ConnectResource> adminResources();
 
+    /**
+     * Pluggable hook to customize the regular (i.e., non-admin) resources on this server
+     * after they have been instantiated and registered with the given {@link ResourceConfig}.
+     * This may be used to, for example, add REST extensions via {@link #registerRestExtensions(Herder, ResourceConfig)}.
+     * <p>
+     * <em>N.B.: Classes do <b>not</b> need to register the resources provided in {@link #regularResources()} with
+     * the {@link ResourceConfig} parameter in this method; they are automatically registered by the parent class.</em>
+     * @param resourceConfig the {@link ResourceConfig} that the server's regular listeners are registered with; never null
+     */
     protected void configureRegularResources(ResourceConfig resourceConfig) {
         // No-op by default
     }
 
+    /**
+     * Pluggable hook to customize the admin resources on this server after they have been instantiated and registered
+     * with the given {@link ResourceConfig}. This may be used to, for example, add REST extensions via
+     * {@link #registerRestExtensions(Herder, ResourceConfig)}.
+     * <p>
+     * <em>N.B.: Classes do <b>not</b> need to register the resources provided in {@link #adminResources()} with
+     * the {@link ResourceConfig} parameter in this method; they are automatically registered by the parent class.</em>
+     * @param adminResourceConfig the {@link ResourceConfig} that the server's regular listeners are registered with; never null
+     */
     protected void configureAdminResources(ResourceConfig adminResourceConfig) {
         // No-op by default
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServerConfig.java
@@ -1,0 +1,479 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.rest;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.SslClientAuth;
+import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.connect.runtime.WorkerConfig;
+import org.eclipse.jetty.util.StringUtil;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.kafka.common.config.ConfigDef.ValidString.in;
+
+/**
+ * Defines the configuration surface for a {@link RestServer} instance, with support for both
+ * {@link #forInternal(Map) internal-only} and {@link #forPublic(Integer, Map) user-facing}
+ * servers. An internal-only server will expose only the endpoints and listeners necessary for
+ * intra-cluster communication; these include the task-write and zombie-fencing endpoints. A
+ * user-facing server will expose these endpoints and, in addition, all endpoints that are part of
+ * the public REST API for Kafka Connect; these include the connector creation, connector
+ * status, configuration validation, and logging endpoints. In addition, a user-facing server will
+ * instantiate any user-configured
+ * {@link RestServerConfig#REST_EXTENSION_CLASSES_CONFIG REST extensions}.
+ */
+public abstract class RestServerConfig extends AbstractConfig {
+
+    public static final String LISTENERS_CONFIG = "listeners";
+    private static final String LISTENERS_DOC
+            = "List of comma-separated URIs the REST API will listen on. The supported protocols are HTTP and HTTPS.\n" +
+            " Specify hostname as 0.0.0.0 to bind to all interfaces.\n" +
+            " Leave hostname empty to bind to default interface.\n" +
+            " Examples of legal listener lists: HTTP://myhost:8083,HTTPS://myhost:8084";
+    // Visible for testing
+    static final List<String> LISTENERS_DEFAULT = Collections.singletonList("http://:8083");
+
+    public static final String REST_ADVERTISED_HOST_NAME_CONFIG = "rest.advertised.host.name";
+    private static final String REST_ADVERTISED_HOST_NAME_DOC
+            = "If this is set, this is the hostname that will be given out to other workers to connect to.";
+
+    public static final String REST_ADVERTISED_PORT_CONFIG = "rest.advertised.port";
+    private static final String REST_ADVERTISED_PORT_DOC
+            = "If this is set, this is the port that will be given out to other workers to connect to.";
+
+    public static final String REST_ADVERTISED_LISTENER_CONFIG = "rest.advertised.listener";
+    private static final String REST_ADVERTISED_LISTENER_DOC
+            = "Sets the advertised listener (HTTP or HTTPS) which will be given to other workers to use.";
+
+    public static final String ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG = "access.control.allow.origin";
+    private static final String ACCESS_CONTROL_ALLOW_ORIGIN_DOC =
+            "Value to set the Access-Control-Allow-Origin header to for REST API requests." +
+                    "To enable cross origin access, set this to the domain of the application that should be permitted" +
+                    " to access the API, or '*' to allow access from any domain. The default value only allows access" +
+                    " from the domain of the REST API.";
+    protected static final String ACCESS_CONTROL_ALLOW_ORIGIN_DEFAULT = "";
+
+    public static final String ACCESS_CONTROL_ALLOW_METHODS_CONFIG = "access.control.allow.methods";
+    private static final String ACCESS_CONTROL_ALLOW_METHODS_DOC =
+            "Sets the methods supported for cross origin requests by setting the Access-Control-Allow-Methods header. "
+                    + "The default value of the Access-Control-Allow-Methods header allows cross origin requests for GET, POST and HEAD.";
+    private static final String ACCESS_CONTROL_ALLOW_METHODS_DEFAULT = "";
+
+    public static final String ADMIN_LISTENERS_CONFIG = "admin.listeners";
+    private static final String ADMIN_LISTENERS_DOC = "List of comma-separated URIs the Admin REST API will listen on." +
+            " The supported protocols are HTTP and HTTPS." +
+            " An empty or blank string will disable this feature." +
+            " The default behavior is to use the regular listener (specified by the 'listeners' property).";
+    public static final String ADMIN_LISTENERS_HTTPS_CONFIGS_PREFIX = "admin.listeners.https.";
+
+    public static final String REST_EXTENSION_CLASSES_CONFIG = "rest.extension.classes";
+    private static final String REST_EXTENSION_CLASSES_DOC =
+            "Comma-separated names of <code>ConnectRestExtension</code> classes, loaded and called "
+                    + "in the order specified. Implementing the interface  "
+                    + "<code>ConnectRestExtension</code> allows you to inject into Connect's REST API user defined resources like filters. "
+                    + "Typically used to add custom capability like logging, security, etc. ";
+
+    // Visible for testing
+    static final String RESPONSE_HTTP_HEADERS_CONFIG = "response.http.headers.config";
+    // Visible for testing
+    static final String RESPONSE_HTTP_HEADERS_DOC = "Rules for REST API HTTP response headers";
+    // Visible for testing
+    static final String RESPONSE_HTTP_HEADERS_DEFAULT = "";
+    private static final Collection<String> HEADER_ACTIONS = Collections.unmodifiableList(
+            Arrays.asList("set", "add", "setDate", "addDate")
+    );
+
+
+    /**
+     * @return the listeners to use for this server, or empty if no admin endpoints should be exposed,
+     * or null if the admin endpoints should be exposed on the {@link #listeners() regular listeners} for
+     * this server
+     */
+    public abstract List<String> adminListeners();
+
+    /**
+     * @return whether this is an internal-only server
+     */
+    public abstract boolean internalOnly();
+
+    /**
+     * @return a list of {@link #REST_EXTENSION_CLASSES_CONFIG REST extension} classes
+     * to instantiate and use with the server
+     */
+    public abstract List<String> restExtensions();
+
+    /**
+     * @return whether {@link WorkerConfig#TOPIC_TRACKING_ENABLE_CONFIG topic tracking}
+     * is enabled on this worker
+     */
+    public abstract boolean topicTrackingEnabled();
+
+    /**
+     * @return whether {@link WorkerConfig#TOPIC_TRACKING_ALLOW_RESET_CONFIG topic tracking resets}
+     * are enabled on this worker
+     */
+    public abstract boolean topicTrackingResetEnabled();
+
+    /**
+     * Add the properties related to a user-facing server to the given {@link ConfigDef}.
+     * </p>
+     * This automatically adds the properties for intra-cluster communication; it is not necessary to
+     * invoke both {@link #addInternalConfig(ConfigDef)} and this method on the same {@link ConfigDef}.
+     * @param configDef the {@link ConfigDef} to add the properties to; may not be null
+     */
+    public static void addPublicConfig(ConfigDef configDef) {
+        addInternalConfig(configDef);
+        configDef
+                .define(
+                        REST_EXTENSION_CLASSES_CONFIG,
+                        ConfigDef.Type.LIST,
+                        "",
+                        ConfigDef.Importance.LOW, REST_EXTENSION_CLASSES_DOC
+                ).define(ADMIN_LISTENERS_CONFIG,
+                        ConfigDef.Type.LIST,
+                        null,
+                        new AdminListenersValidator(),
+                        ConfigDef.Importance.LOW,
+                        ADMIN_LISTENERS_DOC);
+    }
+
+    /**
+     * Add the properties related to an internal-only server to the given {@link ConfigDef}.
+     * @param configDef the {@link ConfigDef} to add the properties to; may not be null
+     */
+    public static void addInternalConfig(ConfigDef configDef) {
+        configDef
+                .define(
+                        LISTENERS_CONFIG,
+                        ConfigDef.Type.LIST,
+                        LISTENERS_DEFAULT,
+                        new ListenersValidator(),
+                        ConfigDef.Importance.LOW,
+                        LISTENERS_DOC
+                ).define(
+                        REST_ADVERTISED_HOST_NAME_CONFIG,
+                        ConfigDef.Type.STRING,
+                        null,
+                        ConfigDef.Importance.LOW,
+                        REST_ADVERTISED_HOST_NAME_DOC
+                ).define(
+                        REST_ADVERTISED_PORT_CONFIG,
+                        ConfigDef.Type.INT,
+                        null,
+                        ConfigDef.Importance.LOW,
+                        REST_ADVERTISED_PORT_DOC
+                ).define(
+                        REST_ADVERTISED_LISTENER_CONFIG,
+                        ConfigDef.Type.STRING,
+                        null,
+                        ConfigDef.Importance.LOW,
+                        REST_ADVERTISED_LISTENER_DOC
+                ).define(
+                        ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG,
+                        ConfigDef.Type.STRING,
+                        ACCESS_CONTROL_ALLOW_ORIGIN_DEFAULT,
+                        ConfigDef.Importance.LOW,
+                        ACCESS_CONTROL_ALLOW_ORIGIN_DOC
+                ).define(
+                        ACCESS_CONTROL_ALLOW_METHODS_CONFIG,
+                        ConfigDef.Type.STRING,
+                        ACCESS_CONTROL_ALLOW_METHODS_DEFAULT,
+                        ConfigDef.Importance.LOW,
+                        ACCESS_CONTROL_ALLOW_METHODS_DOC
+                ).define(
+                        RESPONSE_HTTP_HEADERS_CONFIG,
+                        ConfigDef.Type.STRING,
+                        RESPONSE_HTTP_HEADERS_DEFAULT,
+                        new ResponseHttpHeadersValidator(),
+                        ConfigDef.Importance.LOW,
+                        RESPONSE_HTTP_HEADERS_DOC
+                ).define(
+                        BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG,
+                        ConfigDef.Type.STRING,
+                        SslClientAuth.NONE.toString(),
+                        in(Utils.enumOptions(SslClientAuth.class)),
+                        ConfigDef.Importance.LOW,
+                        BrokerSecurityConfigs.SSL_CLIENT_AUTH_DOC);
+
+    }
+
+    public static RestServerConfig forPublic(Integer rebalanceTimeoutMs, Map<?, ?> props) {
+        return new PublicConfig(rebalanceTimeoutMs, props);
+    }
+
+    public static RestServerConfig forInternal(Map<?, ?> props) {
+        return new InternalConfig(props);
+    }
+
+    public List<String> listeners() {
+        return getList(LISTENERS_CONFIG);
+    }
+
+    public String rawListeners() {
+        return (String) originals().get(LISTENERS_CONFIG);
+    }
+
+    public String allowedOrigins() {
+        return getString(ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG);
+    }
+
+    public String allowedMethods() {
+        return getString(ACCESS_CONTROL_ALLOW_METHODS_CONFIG);
+    }
+
+    public String responseHeaders() {
+        return getString(RESPONSE_HTTP_HEADERS_CONFIG);
+    }
+
+    public String advertisedListener() {
+        return getString(RestServerConfig.REST_ADVERTISED_LISTENER_CONFIG);
+    }
+
+    public String advertisedHostName() {
+        return getString(REST_ADVERTISED_HOST_NAME_CONFIG);
+    }
+
+    public Integer advertisedPort() {
+        return getInt(REST_ADVERTISED_PORT_CONFIG);
+    }
+
+    public Integer rebalanceTimeoutMs() {
+        return null;
+    }
+
+    protected RestServerConfig(ConfigDef configDef, Map<?, ?> props) {
+        super(configDef, props);
+    }
+
+    // Visible for testing
+    static void validateHttpResponseHeaderConfig(String config) {
+        try {
+            // validate format
+            String[] configTokens = config.trim().split("\\s+", 2);
+            if (configTokens.length != 2) {
+                throw new ConfigException(String.format("Invalid format of header config '%s'. "
+                        + "Expected: '[action] [header name]:[header value]'", config));
+            }
+
+            // validate action
+            String method = configTokens[0].trim();
+            validateHeaderConfigAction(method);
+
+            // validate header name and header value pair
+            String header = configTokens[1];
+            String[] headerTokens = header.trim().split(":");
+            if (headerTokens.length != 2) {
+                throw new ConfigException(
+                        String.format("Invalid format of header name and header value pair '%s'. "
+                                + "Expected: '[header name]:[header value]'", header));
+            }
+
+            // validate header name
+            String headerName = headerTokens[0].trim();
+            if (headerName.isEmpty() || headerName.matches(".*\\s+.*")) {
+                throw new ConfigException(String.format("Invalid header name '%s'. "
+                        + "The '[header name]' cannot contain whitespace", headerName));
+            }
+        } catch (ArrayIndexOutOfBoundsException e) {
+            throw new ConfigException(String.format("Invalid header config '%s'.", config), e);
+        }
+    }
+
+    // Visible for testing
+    static void validateHeaderConfigAction(String action) {
+        if (HEADER_ACTIONS.stream().noneMatch(action::equalsIgnoreCase)) {
+            throw new ConfigException(String.format("Invalid header config action: '%s'. "
+                    + "Expected one of %s", action, HEADER_ACTIONS));
+        }
+    }
+
+    private static class ListenersValidator implements ConfigDef.Validator {
+        @Override
+        public void ensureValid(String name, Object value) {
+            if (!(value instanceof List)) {
+                throw new ConfigException("Invalid value type for listeners (expected list of URLs , ex: http://localhost:8080,https://localhost:8443).");
+            }
+
+            List<?> items = (List<?>) value;
+            if (items.isEmpty()) {
+                throw new ConfigException("Invalid value for listeners, at least one URL is expected, ex: http://localhost:8080,https://localhost:8443.");
+            }
+
+            for (Object item : items) {
+                if (!(item instanceof String)) {
+                    throw new ConfigException("Invalid type for listeners (expected String).");
+                }
+                if (Utils.isBlank((String) item)) {
+                    throw new ConfigException("Empty URL found when parsing listeners list.");
+                }
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "List of comma-separated URLs, ex: http://localhost:8080,https://localhost:8443.";
+        }
+    }
+
+    private static class AdminListenersValidator implements ConfigDef.Validator {
+        @Override
+        public void ensureValid(String name, Object value) {
+            if (value == null) {
+                return;
+            }
+
+            if (!(value instanceof List)) {
+                throw new ConfigException("Invalid value type for admin.listeners (expected list).");
+            }
+
+            List<?> items = (List<?>) value;
+            if (items.isEmpty()) {
+                return;
+            }
+
+            for (Object item : items) {
+                if (!(item instanceof String)) {
+                    throw new ConfigException("Invalid type for admin.listeners (expected String).");
+                }
+                if (Utils.isBlank((String) item)) {
+                    throw new ConfigException("Empty URL found when parsing admin.listeners list.");
+                }
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "List of comma-separated URLs, ex: http://localhost:8080,https://localhost:8443.";
+        }
+    }
+
+    private static class ResponseHttpHeadersValidator implements ConfigDef.Validator {
+        @Override
+        public void ensureValid(String name, Object value) {
+            String strValue = (String) value;
+            if (Utils.isBlank(strValue)) {
+                return;
+            }
+
+            String[] configs = StringUtil.csvSplit(strValue); // handles and removed surrounding quotes
+            Arrays.stream(configs).forEach(RestServerConfig::validateHttpResponseHeaderConfig);
+        }
+
+        @Override
+        public String toString() {
+            return "Comma-separated header rules, where each header rule is of the form "
+                    + "'[action] [header name]:[header value]' and optionally surrounded by double quotes "
+                    + "if any part of a header rule contains a comma";
+        }
+    }
+
+    private static class InternalConfig extends RestServerConfig {
+
+        private static ConfigDef config() {
+            ConfigDef result = new ConfigDef().withClientSslSupport();
+            addInternalConfig(result);
+            return result;
+        }
+
+        @Override
+        public List<String> adminListeners() {
+            // Disable admin resources (such as the logging resource)
+            return Collections.emptyList();
+        }
+
+        @Override
+        public boolean internalOnly() {
+            return true;
+        }
+
+        @Override
+        public List<String> restExtensions() {
+            // Disable the use of REST extensions
+            return null;
+        }
+
+        @Override
+        public boolean topicTrackingEnabled() {
+            // Topic tracking is unnecessary if we don't expose a public REST API
+            return false;
+        }
+
+        @Override
+        public boolean topicTrackingResetEnabled() {
+            // Topic tracking is unnecessary if we don't expose a public REST API
+            return false;
+        }
+
+        public InternalConfig(Map<?, ?> props) {
+            super(config(), props);
+        }
+    }
+
+    private static class PublicConfig extends RestServerConfig {
+
+        private final Integer rebalanceTimeoutMs;
+        private static ConfigDef config() {
+            ConfigDef result = new ConfigDef().withClientSslSupport();
+            addPublicConfig(result);
+            WorkerConfig.addTopicTrackingConfig(result);
+            return result;
+        }
+
+        @Override
+        public List<String> adminListeners() {
+            return getList(ADMIN_LISTENERS_CONFIG);
+        }
+
+        @Override
+        public boolean internalOnly() {
+            return false;
+        }
+
+        @Override
+        public List<String> restExtensions() {
+            return getList(REST_EXTENSION_CLASSES_CONFIG);
+        }
+
+        @Override
+        public Integer rebalanceTimeoutMs() {
+            return rebalanceTimeoutMs;
+        }
+
+        @Override
+        public boolean topicTrackingEnabled() {
+            return getBoolean(WorkerConfig.TOPIC_TRACKING_ENABLE_CONFIG);
+        }
+
+        @Override
+        public boolean topicTrackingResetEnabled() {
+            return getBoolean(WorkerConfig.TOPIC_TRACKING_ALLOW_RESET_CONFIG);
+        }
+
+        public PublicConfig(Integer rebalanceTimeoutMs, Map<?, ?> props) {
+            super(config(), props);
+            this.rebalanceTimeoutMs = rebalanceTimeoutMs;
+        }
+    }
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServerConfig.java
@@ -114,11 +114,6 @@ public abstract class RestServerConfig extends AbstractConfig {
     public abstract List<String> adminListeners();
 
     /**
-     * @return whether this is an internal-only server
-     */
-    public abstract boolean internalOnly();
-
-    /**
      * @return a list of {@link #REST_EXTENSION_CLASSES_CONFIG REST extension} classes
      * to instantiate and use with the server
      */
@@ -216,7 +211,6 @@ public abstract class RestServerConfig extends AbstractConfig {
                         in(Utils.enumOptions(SslClientAuth.class)),
                         ConfigDef.Importance.LOW,
                         BrokerSecurityConfigs.SSL_CLIENT_AUTH_DOC);
-
     }
 
     public static RestServerConfig forPublic(Integer rebalanceTimeoutMs, Map<?, ?> props) {
@@ -404,11 +398,6 @@ public abstract class RestServerConfig extends AbstractConfig {
         }
 
         @Override
-        public boolean internalOnly() {
-            return true;
-        }
-
-        @Override
         public List<String> restExtensions() {
             // Disable the use of REST extensions
             return null;
@@ -444,11 +433,6 @@ public abstract class RestServerConfig extends AbstractConfig {
         @Override
         public List<String> adminListeners() {
             return getList(ADMIN_LISTENERS_CONFIG);
-        }
-
-        @Override
-        public boolean internalOnly() {
-            return false;
         }
 
         @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -28,11 +28,10 @@ import org.apache.kafka.connect.errors.NotFoundException;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.RestartRequest;
-import org.apache.kafka.connect.runtime.WorkerConfig;
-import org.apache.kafka.connect.runtime.distributed.RebalanceNeededException;
-import org.apache.kafka.connect.runtime.distributed.RequestTargetException;
+import org.apache.kafka.connect.runtime.rest.HerderRequestHandler;
 import org.apache.kafka.connect.runtime.rest.InternalRequestSignature;
 import org.apache.kafka.connect.runtime.rest.RestClient;
+import org.apache.kafka.connect.runtime.rest.RestServerConfig;
 import org.apache.kafka.connect.runtime.rest.entities.ActiveTopicsInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
@@ -66,12 +65,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
-import static org.apache.kafka.connect.runtime.WorkerConfig.TOPIC_TRACKING_ALLOW_RESET_CONFIG;
-import static org.apache.kafka.connect.runtime.WorkerConfig.TOPIC_TRACKING_ENABLE_CONFIG;
+import static org.apache.kafka.connect.runtime.rest.HerderRequestHandler.Translator;
+import static org.apache.kafka.connect.runtime.rest.HerderRequestHandler.IdentityTranslator;
 
 @Path("/connectors")
 @Produces(MediaType.APPLICATION_JSON)
@@ -82,27 +78,22 @@ public class ConnectorsResource implements ConnectResource {
         new TypeReference<List<Map<String, String>>>() { };
 
     private final Herder herder;
-    private final WorkerConfig config;
-    private long requestTimeoutMs;
+    private final HerderRequestHandler requestHandler;
     @javax.ws.rs.core.Context
     private ServletContext context;
     private final boolean isTopicTrackingDisabled;
     private final boolean isTopicTrackingResetDisabled;
 
-    public ConnectorsResource(Herder herder, WorkerConfig config) {
+    public ConnectorsResource(Herder herder, RestServerConfig config) {
         this.herder = herder;
-        this.config = config;
-        isTopicTrackingDisabled = !config.getBoolean(TOPIC_TRACKING_ENABLE_CONFIG);
-        isTopicTrackingResetDisabled = !config.getBoolean(TOPIC_TRACKING_ALLOW_RESET_CONFIG);
-        this.requestTimeoutMs = DEFAULT_REST_REQUEST_TIMEOUT_MS;
+        this.requestHandler = new HerderRequestHandler(config, DEFAULT_REST_REQUEST_TIMEOUT_MS);
+        this.isTopicTrackingDisabled = !config.topicTrackingEnabled();
+        this.isTopicTrackingResetDisabled = !config.topicTrackingResetEnabled();
     }
 
     @Override
     public void requestTimeout(long requestTimeoutMs) {
-        if (requestTimeoutMs < 1) {
-            throw new IllegalArgumentException("REST request timeout must be positive");
-        }
-        this.requestTimeoutMs = requestTimeoutMs;
+        requestHandler.requestTimeoutMs(requestTimeoutMs);
     }
 
     @GET
@@ -159,7 +150,7 @@ public class ConnectorsResource implements ConnectResource {
 
         FutureCallback<Herder.Created<ConnectorInfo>> cb = new FutureCallback<>();
         herder.putConnectorConfig(name, configs, false, cb);
-        Herder.Created<ConnectorInfo> info = completeOrForwardRequest(cb, "/connectors", "POST", headers, createRequest,
+        Herder.Created<ConnectorInfo> info = requestHandler.completeOrForwardRequest(cb, "/connectors", "POST", headers, createRequest,
                 new TypeReference<ConnectorInfo>() { }, new CreatedConnectorInfoTranslator(), forward);
 
         URI location = UriBuilder.fromUri("/connectors").path(name).build();
@@ -174,7 +165,7 @@ public class ConnectorsResource implements ConnectResource {
                                       final @Parameter(hidden = true) @QueryParam("forward") Boolean forward) throws Throwable {
         FutureCallback<ConnectorInfo> cb = new FutureCallback<>();
         herder.connectorInfo(connector, cb);
-        return completeOrForwardRequest(cb, "/connectors/" + connector, "GET", headers, null, forward);
+        return requestHandler.completeOrForwardRequest(cb, "/connectors/" + connector, "GET", headers, null, forward);
     }
 
     @GET
@@ -185,7 +176,7 @@ public class ConnectorsResource implements ConnectResource {
                                                   final @Parameter(hidden = true) @QueryParam("forward") Boolean forward) throws Throwable {
         FutureCallback<Map<String, String>> cb = new FutureCallback<>();
         herder.connectorConfig(connector, cb);
-        return completeOrForwardRequest(cb, "/connectors/" + connector + "/config", "GET", headers, null, forward);
+        return requestHandler.completeOrForwardRequest(cb, "/connectors/" + connector + "/config", "GET", headers, null, forward);
     }
 
     @GET
@@ -197,7 +188,7 @@ public class ConnectorsResource implements ConnectResource {
             final @Parameter(hidden = true) @QueryParam("forward") Boolean forward) throws Throwable {
         FutureCallback<Map<ConnectorTaskId, Map<String, String>>> cb = new FutureCallback<>();
         herder.tasksConfig(connector, cb);
-        return completeOrForwardRequest(cb, "/connectors/" + connector + "/tasks-config", "GET", headers, null, forward);
+        return requestHandler.completeOrForwardRequest(cb, "/connectors/" + connector + "/tasks-config", "GET", headers, null, forward);
     }
 
     @GET
@@ -246,7 +237,7 @@ public class ConnectorsResource implements ConnectResource {
         checkAndPutConnectorConfigName(connector, connectorConfig);
 
         herder.putConnectorConfig(connector, connectorConfig, true, cb);
-        Herder.Created<ConnectorInfo> createdInfo = completeOrForwardRequest(cb, "/connectors/" + connector + "/config",
+        Herder.Created<ConnectorInfo> createdInfo = requestHandler.completeOrForwardRequest(cb, "/connectors/" + connector + "/config",
                 "PUT", headers, connectorConfig, new TypeReference<ConnectorInfo>() { }, new CreatedConnectorInfoTranslator(), forward);
         Response.ResponseBuilder response;
         if (createdInfo.created()) {
@@ -272,7 +263,7 @@ public class ConnectorsResource implements ConnectResource {
             // For backward compatibility, just restart the connector instance and return OK with no body
             FutureCallback<Void> cb = new FutureCallback<>();
             herder.restartConnector(connector, cb);
-            completeOrForwardRequest(cb, forwardingPath, "POST", headers, null, forward);
+            requestHandler.completeOrForwardRequest(cb, forwardingPath, "POST", headers, null, forward);
             return Response.noContent().build();
         }
 
@@ -282,7 +273,7 @@ public class ConnectorsResource implements ConnectResource {
         Map<String, String> queryParameters = new HashMap<>();
         queryParameters.put("includeTasks", includeTasks.toString());
         queryParameters.put("onlyFailed", onlyFailed.toString());
-        ConnectorStateInfo stateInfo = completeOrForwardRequest(cb, forwardingPath, "POST", headers, queryParameters, null, new TypeReference<ConnectorStateInfo>() {
+        ConnectorStateInfo stateInfo = requestHandler.completeOrForwardRequest(cb, forwardingPath, "POST", headers, queryParameters, null, new TypeReference<ConnectorStateInfo>() {
         }, new IdentityTranslator<>(), forward);
         return Response.accepted().entity(stateInfo).build();
     }
@@ -313,8 +304,7 @@ public class ConnectorsResource implements ConnectResource {
                                          final @Parameter(hidden = true) @QueryParam("forward") Boolean forward) throws Throwable {
         FutureCallback<List<TaskInfo>> cb = new FutureCallback<>();
         herder.taskConfigs(connector, cb);
-        return completeOrForwardRequest(cb, "/connectors/" + connector + "/tasks", "GET", headers, null, new TypeReference<List<TaskInfo>>() {
-        }, forward);
+        return requestHandler.completeOrForwardRequest(cb, "/connectors/" + connector + "/tasks", "GET", headers, null, new TypeReference<List<TaskInfo>>() { }, forward);
     }
 
     @POST
@@ -327,7 +317,7 @@ public class ConnectorsResource implements ConnectResource {
         List<Map<String, String>> taskConfigs = new ObjectMapper().readValue(requestBody, TASK_CONFIGS_TYPE);
         FutureCallback<Void> cb = new FutureCallback<>();
         herder.putTaskConfigs(connector, taskConfigs, cb, InternalRequestSignature.fromHeaders(requestBody, headers));
-        completeOrForwardRequest(cb, "/connectors/" + connector + "/tasks", "POST", headers, taskConfigs, forward);
+        requestHandler.completeOrForwardRequest(cb, "/connectors/" + connector + "/tasks", "POST", headers, taskConfigs, forward);
     }
 
     @PUT
@@ -339,7 +329,7 @@ public class ConnectorsResource implements ConnectResource {
                              final byte[] requestBody) throws Throwable {
         FutureCallback<Void> cb = new FutureCallback<>();
         herder.fenceZombieSourceTasks(connector, cb, InternalRequestSignature.fromHeaders(requestBody, headers));
-        completeOrForwardRequest(cb, "/connectors/" + connector + "/fence", "PUT", headers, requestBody, forward);
+        requestHandler.completeOrForwardRequest(cb, "/connectors/" + connector + "/fence", "PUT", headers, requestBody, forward);
     }
 
     @GET
@@ -361,7 +351,7 @@ public class ConnectorsResource implements ConnectResource {
         FutureCallback<Void> cb = new FutureCallback<>();
         ConnectorTaskId taskId = new ConnectorTaskId(connector, task);
         herder.restartTask(taskId, cb);
-        completeOrForwardRequest(cb, "/connectors/" + connector + "/tasks/" + task + "/restart", "POST", headers, null, forward);
+        requestHandler.completeOrForwardRequest(cb, "/connectors/" + connector + "/tasks/" + task + "/restart", "POST", headers, null, forward);
     }
 
     @DELETE
@@ -372,7 +362,7 @@ public class ConnectorsResource implements ConnectResource {
                                  final @Parameter(hidden = true) @QueryParam("forward") Boolean forward) throws Throwable {
         FutureCallback<Herder.Created<ConnectorInfo>> cb = new FutureCallback<>();
         herder.deleteConnectorConfig(connector, cb);
-        completeOrForwardRequest(cb, "/connectors/" + connector, "DELETE", headers, null, forward);
+        requestHandler.completeOrForwardRequest(cb, "/connectors/" + connector, "DELETE", headers, null, forward);
     }
 
     // Check whether the connector name from the url matches the one (if there is one) provided in the connectorConfig
@@ -384,92 +374,6 @@ public class ConnectorsResource implements ConnectResource {
                 throw new BadRequestException("Connector name configuration (" + includedName + ") doesn't match connector name in the URL (" + connectorName + ")");
         } else {
             connectorConfig.put(ConnectorConfig.NAME_CONFIG, connectorName);
-        }
-    }
-
-    // Wait for a FutureCallback to complete. If it succeeds, return the parsed response. If it fails, try to forward the
-    // request to the leader.
-    private <T, U> T completeOrForwardRequest(FutureCallback<T> cb,
-                                              String path,
-                                              String method,
-                                              HttpHeaders headers,
-                                              Map<String, String> queryParameters,
-                                              Object body,
-                                              TypeReference<U> resultType,
-                                              Translator<T, U> translator,
-                                              Boolean forward) throws Throwable {
-        try {
-            return cb.get(requestTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            Throwable cause = e.getCause();
-
-            if (cause instanceof RequestTargetException) {
-                if (forward == null || forward) {
-                    // the only time we allow recursive forwarding is when no forward flag has
-                    // been set, which should only be seen by the first worker to handle a user request.
-                    // this gives two total hops to resolve the request before giving up.
-                    boolean recursiveForward = forward == null;
-                    RequestTargetException targetException = (RequestTargetException) cause;
-                    String forwardedUrl = targetException.forwardUrl();
-                    if (forwardedUrl == null) {
-                        // the target didn't know of the leader at this moment.
-                        throw new ConnectRestException(Response.Status.CONFLICT.getStatusCode(),
-                                "Cannot complete request momentarily due to no known leader URL, "
-                                + "likely because a rebalance was underway.");
-                    }
-                    UriBuilder uriBuilder = UriBuilder.fromUri(forwardedUrl)
-                            .path(path)
-                            .queryParam("forward", recursiveForward);
-                    if (queryParameters != null) {
-                        queryParameters.forEach(uriBuilder::queryParam);
-                    }
-                    String forwardUrl = uriBuilder.build().toString();
-                    log.debug("Forwarding request {} {} {}", forwardUrl, method, body);
-                    return translator.translate(RestClient.httpRequest(forwardUrl, method, headers, body, resultType, config));
-                } else {
-                    // we should find the right target for the query within two hops, so if
-                    // we don't, it probably means that a rebalance has taken place.
-                    throw new ConnectRestException(Response.Status.CONFLICT.getStatusCode(),
-                            "Cannot complete request because of a conflicting operation (e.g. worker rebalance)");
-                }
-            } else if (cause instanceof RebalanceNeededException) {
-                throw new ConnectRestException(Response.Status.CONFLICT.getStatusCode(),
-                        "Cannot complete request momentarily due to stale configuration (typically caused by a concurrent config change)");
-            }
-
-            throw cause;
-        } catch (TimeoutException e) {
-            // This timeout is for the operation itself. None of the timeout error codes are relevant, so internal server
-            // error is the best option
-            throw new ConnectRestException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), "Request timed out");
-        } catch (InterruptedException e) {
-            throw new ConnectRestException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), "Request interrupted");
-        }
-    }
-
-    private <T, U> T completeOrForwardRequest(FutureCallback<T> cb, String path, String method, HttpHeaders headers, Object body,
-                                              TypeReference<U> resultType, Translator<T, U> translator, Boolean forward) throws Throwable {
-        return completeOrForwardRequest(cb, path, method, headers, null, body, resultType, translator, forward);
-    }
-
-    private <T> T completeOrForwardRequest(FutureCallback<T> cb, String path, String method, HttpHeaders headers, Object body,
-                                           TypeReference<T> resultType, Boolean forward) throws Throwable {
-        return completeOrForwardRequest(cb, path, method, headers, body, resultType, new IdentityTranslator<>(), forward);
-    }
-
-    private <T> T completeOrForwardRequest(FutureCallback<T> cb, String path, String method, HttpHeaders headers,
-                                           Object body, Boolean forward) throws Throwable {
-        return completeOrForwardRequest(cb, path, method, headers, body, null, new IdentityTranslator<>(), forward);
-    }
-
-    private interface Translator<T, U> {
-        T translate(RestClient.HttpResponse<U> response);
-    }
-
-    private static class IdentityTranslator<T> implements Translator<T, T> {
-        @Override
-        public T translate(RestClient.HttpResponse<T> response) {
-            return response.body();
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.core.HttpHeaders;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import org.apache.kafka.connect.errors.NotFoundException;
@@ -29,7 +28,6 @@ import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.RestartRequest;
 import org.apache.kafka.connect.runtime.rest.HerderRequestHandler;
-import org.apache.kafka.connect.runtime.rest.InternalRequestSignature;
 import org.apache.kafka.connect.runtime.rest.RestClient;
 import org.apache.kafka.connect.runtime.rest.RestServerConfig;
 import org.apache.kafka.connect.runtime.rest.entities.ActiveTopicsInfo;
@@ -305,31 +303,6 @@ public class ConnectorsResource implements ConnectResource {
         FutureCallback<List<TaskInfo>> cb = new FutureCallback<>();
         herder.taskConfigs(connector, cb);
         return requestHandler.completeOrForwardRequest(cb, "/connectors/" + connector + "/tasks", "GET", headers, null, new TypeReference<List<TaskInfo>>() { }, forward);
-    }
-
-    @POST
-    @Path("/{connector}/tasks")
-    @Operation(hidden = true, summary = "This operation is only for inter-worker communications")
-    public void putTaskConfigs(final @PathParam("connector") String connector,
-                               final @Context HttpHeaders headers,
-                               final @QueryParam("forward") Boolean forward,
-                               final byte[] requestBody) throws Throwable {
-        List<Map<String, String>> taskConfigs = new ObjectMapper().readValue(requestBody, TASK_CONFIGS_TYPE);
-        FutureCallback<Void> cb = new FutureCallback<>();
-        herder.putTaskConfigs(connector, taskConfigs, cb, InternalRequestSignature.fromHeaders(requestBody, headers));
-        requestHandler.completeOrForwardRequest(cb, "/connectors/" + connector + "/tasks", "POST", headers, taskConfigs, forward);
-    }
-
-    @PUT
-    @Path("/{connector}/fence")
-    @Operation(hidden = true, summary = "This operation is only for inter-worker communications")
-    public void fenceZombies(final @PathParam("connector") String connector,
-                             final @Context HttpHeaders headers,
-                             final @QueryParam("forward") Boolean forward,
-                             final byte[] requestBody) throws Throwable {
-        FutureCallback<Void> cb = new FutureCallback<>();
-        herder.fenceZombieSourceTasks(connector, cb, InternalRequestSignature.fromHeaders(requestBody, headers));
-        requestHandler.completeOrForwardRequest(cb, "/connectors/" + connector + "/fence", "PUT", headers, requestBody, forward);
     }
 
     @GET

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/InternalClusterResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/InternalClusterResource.java
@@ -14,22 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.connect.mirror.rest.resources;
+package org.apache.kafka.connect.runtime.rest.resources;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import org.apache.kafka.common.config.AbstractConfig;
-import org.apache.kafka.connect.mirror.SourceAndTarget;
 import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.rest.HerderRequestHandler;
 import org.apache.kafka.connect.runtime.rest.InternalRequestSignature;
-import org.apache.kafka.connect.runtime.rest.resources.ConnectResource;
 import org.apache.kafka.connect.util.FutureCallback;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -39,23 +34,28 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriInfo;
 import java.util.List;
 import java.util.Map;
 
-@Path("/")
+/**
+ * Contains endpoints necessary for intra-cluster communication--that is, requests that
+ * workers will issue to each other that originate from within the cluster, as opposed to
+ * requests that originate from a user and are forwarded from one worker to another.
+ */
 @Produces(MediaType.APPLICATION_JSON)
-public class InternalConnectorsResource implements ConnectResource {
-
-    private static final Logger log = LoggerFactory.getLogger(InternalConnectorsResource.class);
+public abstract class InternalClusterResource implements ConnectResource {
 
     private static final TypeReference<List<Map<String, String>>> TASK_CONFIGS_TYPE =
             new TypeReference<List<Map<String, String>>>() { };
 
-    private final Map<SourceAndTarget, Herder> herders;
     private final HerderRequestHandler requestHandler;
 
-    public InternalConnectorsResource(Map<SourceAndTarget, Herder> herders, AbstractConfig serverConfig) {
-        this.herders = herders;
+    // Visible for testing
+    @Context
+    UriInfo uriInfo;
+
+    protected InternalClusterResource(AbstractConfig serverConfig) {
         this.requestHandler = new HerderRequestHandler(serverConfig, DEFAULT_REST_REQUEST_TIMEOUT_MS);
     }
 
@@ -64,22 +64,25 @@ public class InternalConnectorsResource implements ConnectResource {
         requestHandler.requestTimeoutMs(requestTimeoutMs);
     }
 
+    /**
+     * @return a {@link Herder} instance that can be used to satisfy the current request; may not be null
+     */
+    protected abstract Herder herderForRequest();
+
     @POST
-    @Path("/{source}/{target}/connectors/{connector}/tasks")
+    @Path("/{connector}/tasks")
     @Operation(hidden = true, summary = "This operation is only for inter-worker communications")
     public void putTaskConfigs(
-            final @PathParam("source") String source,
-            final @PathParam("target") String target,
             final @PathParam("connector") String connector,
             final @Context HttpHeaders headers,
             final @QueryParam("forward") Boolean forward,
             final byte[] requestBody) throws Throwable {
         List<Map<String, String>> taskConfigs = new ObjectMapper().readValue(requestBody, TASK_CONFIGS_TYPE);
         FutureCallback<Void> cb = new FutureCallback<>();
-        herder(source, target).putTaskConfigs(connector, taskConfigs, cb, InternalRequestSignature.fromHeaders(requestBody, headers));
+        herderForRequest().putTaskConfigs(connector, taskConfigs, cb, InternalRequestSignature.fromHeaders(requestBody, headers));
         requestHandler.completeOrForwardRequest(
                 cb,
-                source + "/" + target + "/connectors/" + connector + "/tasks",
+                uriInfo.getPath(),
                 "POST",
                 headers,
                 taskConfigs,
@@ -88,20 +91,18 @@ public class InternalConnectorsResource implements ConnectResource {
     }
 
     @PUT
-    @Path("/{source}/{target}/connectors/{connector}/fence")
+    @Path("/{connector}/fence")
     @Operation(hidden = true, summary = "This operation is only for inter-worker communications")
     public void fenceZombies(
-            final @PathParam("source") String source,
-            final @PathParam("target") String target,
             final @PathParam("connector") String connector,
             final @Context HttpHeaders headers,
             final @QueryParam("forward") Boolean forward,
             final byte[] requestBody) throws Throwable {
         FutureCallback<Void> cb = new FutureCallback<>();
-        herder(source, target).fenceZombieSourceTasks(connector, cb, InternalRequestSignature.fromHeaders(requestBody, headers));
+        herderForRequest().fenceZombieSourceTasks(connector, cb, InternalRequestSignature.fromHeaders(requestBody, headers));
         requestHandler.completeOrForwardRequest(
                 cb,
-                source + "/" + target + "/connectors/" + connector + "/fence",
+                uriInfo.getPath(),
                 "PUT",
                 headers,
                 requestBody,
@@ -109,12 +110,4 @@ public class InternalConnectorsResource implements ConnectResource {
         );
     }
 
-    private Herder herder(String source, String target) {
-        Herder result = herders.get(new SourceAndTarget(source, target));
-        if (result == null) {
-            log.debug("Failed to find herder for source '{}' and target '{}'", source, target);
-            throw new NotFoundException("No replication flow found for source '" + source + "' and target '" + target + "'");
-        }
-        return result;
-    }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/InternalConnectResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/InternalConnectResource.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.rest.resources;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.connect.runtime.Herder;
+
+import javax.ws.rs.Path;
+
+@Path("/connectors")
+public class InternalConnectResource extends InternalClusterResource {
+
+    private final Herder herder;
+
+    public InternalConnectResource(Herder herder, AbstractConfig serverConfig) {
+        super(serverConfig);
+        this.herder = herder;
+    }
+
+    @Override
+    protected Herder herderForRequest() {
+        return herder;
+    }
+
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/util/SSLUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/util/SSLUtils.java
@@ -16,10 +16,10 @@
  */
 package org.apache.kafka.connect.runtime.rest.util;
 
+import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 import org.apache.kafka.common.config.types.Password;
-import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 import java.util.Arrays;
@@ -38,7 +38,7 @@ public class SSLUtils {
     /**
      * Configures SSL/TLS for HTTPS Jetty Server using configs with the given prefix
      */
-    public static SslContextFactory createServerSideSslContextFactory(WorkerConfig config, String prefix) {
+    public static SslContextFactory createServerSideSslContextFactory(AbstractConfig config, String prefix) {
         Map<String, Object> sslConfigValues = config.valuesWithPrefixAllOrNothing(prefix);
 
         final SslContextFactory.Server ssl = new SslContextFactory.Server();
@@ -54,14 +54,14 @@ public class SSLUtils {
     /**
      * Configures SSL/TLS for HTTPS Jetty Server
      */
-    public static SslContextFactory createServerSideSslContextFactory(WorkerConfig config) {
+    public static SslContextFactory createServerSideSslContextFactory(AbstractConfig config) {
         return createServerSideSslContextFactory(config, "listeners.https.");
     }
 
     /**
      * Configures SSL/TLS for HTTPS Jetty Client
      */
-    public static SslContextFactory createClientSideSslContextFactory(WorkerConfig config) {
+    public static SslContextFactory createClientSideSslContextFactory(AbstractConfig config) {
         Map<String, Object> sslConfigValues = config.valuesWithPrefixAllOrNothing("listeners.https.");
 
         final SslContextFactory.Client ssl = new SslContextFactory.Client();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/ConnectUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/ConnectUtils.java
@@ -192,4 +192,5 @@ public final class ConnectUtils {
         }
         return result + "-";
     }
+
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RestExtensionIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RestExtensionIntegrationTest.java
@@ -44,7 +44,7 @@ import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_C
 import static org.apache.kafka.connect.runtime.ConnectorConfig.NAME_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
 import static org.apache.kafka.connect.runtime.SinkConnectorConfig.TOPICS_CONFIG;
-import static org.apache.kafka.connect.runtime.WorkerConfig.REST_EXTENSION_CLASSES_CONFIG;
+import static org.apache.kafka.connect.runtime.rest.RestServerConfig.REST_EXTENSION_CLASSES_CONFIG;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
 import static org.junit.Assert.assertEquals;
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerConfigTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerConfigTest.java
@@ -19,8 +19,6 @@ package org.apache.kafka.connect.runtime;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.MockAdminClient;
 import org.apache.kafka.common.Node;
-import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.After;
 import org.junit.Before;
@@ -33,40 +31,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
 
-import static org.apache.kafka.connect.runtime.WorkerConfig.LISTENERS_DEFAULT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 
 public class WorkerConfigTest {
-    private static final List<String> VALID_HEADER_CONFIGS = Arrays.asList(
-            "add \t Cache-Control: no-cache, no-store, must-revalidate",
-            "add \r X-XSS-Protection: 1; mode=block",
-            "\n add Strict-Transport-Security: max-age=31536000; includeSubDomains",
-            "AdD   Strict-Transport-Security:  \r  max-age=31536000;  includeSubDomains",
-            "AdD \t Strict-Transport-Security : \n   max-age=31536000;  includeSubDomains",
-            "add X-Content-Type-Options: \r nosniff",
-            "Set \t X-Frame-Options: \t Deny\n ",
-            "seT \t X-Cache-Info: \t not cacheable\n ",
-            "seTDate \t Expires: \r 31540000000",
-            "adDdate \n Last-Modified: \t 0"
-    );
-
-    private static final List<String> INVALID_HEADER_CONFIGS = Arrays.asList(
-            "set \t",
-            "badaction \t X-Frame-Options:DENY",
-            "set add X-XSS-Protection:1",
-            "addX-XSS-Protection",
-            "X-XSS-Protection:",
-            "add set X-XSS-Protection: 1",
-            "add X-XSS-Protection:1 X-XSS-Protection:1 ",
-            "add X-XSS-Protection",
-            "set X-Frame-Options:DENY, add  :no-cache, no-store, must-revalidate "
-    );
 
     private static final String CLUSTER_ID = "cluster-id";
     private MockedStatic<WorkerConfig> workerConfigMockedStatic;
@@ -80,105 +52,6 @@ public class WorkerConfigTest {
     @After
     public void teardown() {
         workerConfigMockedStatic.close();
-    }
-
-    @Test
-    public void testListenersConfigAllowedValues() {
-        Map<String, String> props = baseProps();
-
-        // no value set for "listeners"
-        WorkerConfig config = new WorkerConfig(WorkerConfig.baseConfigDef(), props);
-        assertEquals(LISTENERS_DEFAULT, config.getList(WorkerConfig.LISTENERS_CONFIG));
-
-        props.put(WorkerConfig.LISTENERS_CONFIG, "http://a.b:9999");
-        config = new WorkerConfig(WorkerConfig.baseConfigDef(), props);
-        assertEquals(Arrays.asList("http://a.b:9999"), config.getList(WorkerConfig.LISTENERS_CONFIG));
-
-        props.put(WorkerConfig.LISTENERS_CONFIG, "http://a.b:9999, https://a.b:7812");
-        config = new WorkerConfig(WorkerConfig.baseConfigDef(), props);
-        assertEquals(Arrays.asList("http://a.b:9999", "https://a.b:7812"), config.getList(WorkerConfig.LISTENERS_CONFIG));
-
-        new WorkerConfig(WorkerConfig.baseConfigDef(), props);
-    }
-
-    @Test
-    public void testListenersConfigNotAllowedValues() {
-        Map<String, String> props = baseProps();
-        assertEquals(LISTENERS_DEFAULT, new WorkerConfig(WorkerConfig.baseConfigDef(), props).getList(WorkerConfig.LISTENERS_CONFIG));
-
-        props.put(WorkerConfig.LISTENERS_CONFIG, "");
-        ConfigException ce = assertThrows(ConfigException.class, () -> new WorkerConfig(WorkerConfig.baseConfigDef(), props));
-        assertTrue(ce.getMessage().contains(" listeners"));
-
-        props.put(WorkerConfig.LISTENERS_CONFIG, ",,,");
-        ce = assertThrows(ConfigException.class, () -> new WorkerConfig(WorkerConfig.baseConfigDef(), props));
-        assertTrue(ce.getMessage().contains(" listeners"));
-
-        props.put(WorkerConfig.LISTENERS_CONFIG, "http://a.b:9999,");
-        ce = assertThrows(ConfigException.class, () -> new WorkerConfig(WorkerConfig.baseConfigDef(), props));
-        assertTrue(ce.getMessage().contains(" listeners"));
-
-        props.put(WorkerConfig.LISTENERS_CONFIG, "http://a.b:9999, ,https://a.b:9999");
-        ce = assertThrows(ConfigException.class, () -> new WorkerConfig(WorkerConfig.baseConfigDef(), props));
-        assertTrue(ce.getMessage().contains(" listeners"));
-    }
-
-    @Test
-    public void testAdminListenersConfigAllowedValues() {
-        Map<String, String> props = baseProps();
-
-        // no value set for "admin.listeners"
-        WorkerConfig config = new WorkerConfig(WorkerConfig.baseConfigDef(), props);
-        assertNull("Default value should be null.", config.getList(WorkerConfig.ADMIN_LISTENERS_CONFIG));
-
-        props.put(WorkerConfig.ADMIN_LISTENERS_CONFIG, "");
-        config = new WorkerConfig(WorkerConfig.baseConfigDef(), props);
-        assertTrue(config.getList(WorkerConfig.ADMIN_LISTENERS_CONFIG).isEmpty());
-
-        props.put(WorkerConfig.ADMIN_LISTENERS_CONFIG, "http://a.b:9999, https://a.b:7812");
-        config = new WorkerConfig(WorkerConfig.baseConfigDef(), props);
-        assertEquals(Arrays.asList("http://a.b:9999", "https://a.b:7812"), config.getList(WorkerConfig.ADMIN_LISTENERS_CONFIG));
-
-        new WorkerConfig(WorkerConfig.baseConfigDef(), props);
-    }
-
-    @Test
-    public void testAdminListenersNotAllowingEmptyStrings() {
-        Map<String, String> props = baseProps();
-
-        props.put(WorkerConfig.ADMIN_LISTENERS_CONFIG, "http://a.b:9999,");
-        ConfigException ce = assertThrows(ConfigException.class, () -> new WorkerConfig(WorkerConfig.baseConfigDef(), props));
-        assertTrue(ce.getMessage().contains(" admin.listeners"));
-    }
-
-    @Test
-    public void testAdminListenersNotAllowingBlankStrings() {
-        Map<String, String> props = baseProps();
-        props.put(WorkerConfig.ADMIN_LISTENERS_CONFIG, "http://a.b:9999, ,https://a.b:9999");
-        assertThrows(ConfigException.class, () -> new WorkerConfig(WorkerConfig.baseConfigDef(), props));
-    }
-
-    @Test
-    public void testInvalidHeaderConfigs() {
-        for (String config : INVALID_HEADER_CONFIGS) {
-            assertInvalidHeaderConfig(config);
-        }
-    }
-
-    @Test
-    public void testValidHeaderConfigs() {
-        for (String config : VALID_HEADER_CONFIGS) {
-            assertValidHeaderConfig(config);
-        }
-    }
-
-    @Test
-    public void testInvalidSslClientAuthConfig() {
-        Map<String, String> props = baseProps();
-
-        props.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "abc");
-        ConfigException ce = assertThrows(ConfigException.class, () -> new WorkerConfig(WorkerConfig.baseConfigDef(), props));
-        assertTrue(ce.getMessage().contains(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG));
     }
 
     @Test
@@ -223,14 +96,6 @@ public class WorkerConfigTest {
         // next calls hit the cache
         assertEquals(CLUSTER_ID, config.kafkaClusterId());
         workerConfigMockedStatic.verify(() -> WorkerConfig.lookupKafkaClusterId(any(WorkerConfig.class)), times(1));
-    }
-
-    private void assertInvalidHeaderConfig(String config) {
-        assertThrows(ConfigException.class, () -> WorkerConfig.validateHttpResponseHeaderConfig(config));
-    }
-
-    private void assertValidHeaderConfig(String config) {
-        WorkerConfig.validateHttpResponseHeaderConfig(config);
     }
 
     private Map<String, String> baseProps() {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -241,7 +241,7 @@ public class DistributedHerderTest {
                 new String[]{"connectorType", "updateDeletedConnectorStatus", "updateDeletedTaskStatus", "validateConnectorConfig", "buildRestartPlan", "recordRestarting"},
                 new DistributedConfig(HERDER_CONFIG), worker, WORKER_ID, KAFKA_CLUSTER_ID,
                 statusBackingStore, configBackingStore, member, MEMBER_URL, metrics, time, noneConnectorClientConfigOverridePolicy,
-                new AutoCloseable[]{uponShutdown});
+                Collections.emptyList(), new AutoCloseable[]{uponShutdown});
 
         configUpdateListener = herder.new ConfigUpdateListener();
         rebalanceListener = herder.new RebalanceListener(time);
@@ -3836,7 +3836,7 @@ public class DistributedHerderTest {
                 new String[]{"connectorType", "updateDeletedConnectorStatus", "updateDeletedTaskStatus", "validateConnectorConfig"},
                 new DistributedConfig(config), worker, WORKER_ID, KAFKA_CLUSTER_ID,
                 statusBackingStore, configBackingStore, member, MEMBER_URL, metrics, time, noneConnectorClientConfigOverridePolicy,
-                new AutoCloseable[0]);
+                Collections.emptyList(), new AutoCloseable[0]);
     }
 
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginsTest.java
@@ -33,6 +33,7 @@ import org.apache.kafka.connect.rest.ConnectRestExtension;
 import org.apache.kafka.connect.rest.ConnectRestExtensionContext;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.isolation.Plugins.ClassLoaderUsage;
+import org.apache.kafka.connect.runtime.rest.RestServerConfig;
 import org.apache.kafka.connect.storage.Converter;
 import org.apache.kafka.connect.storage.ConverterConfig;
 import org.apache.kafka.connect.storage.ConverterType;
@@ -133,12 +134,13 @@ public class PluginsTest {
 
     @Test
     public void shouldInstantiateAndConfigureConnectRestExtension() {
-        props.put(WorkerConfig.REST_EXTENSION_CLASSES_CONFIG,
+        props.clear();
+        props.put(RestServerConfig.REST_EXTENSION_CLASSES_CONFIG,
                   TestConnectRestExtension.class.getName());
-        createConfig();
+        config = RestServerConfig.forPublic(null, props);
 
         List<ConnectRestExtension> connectRestExtensions =
-            plugins.newPlugins(config.getList(WorkerConfig.REST_EXTENSION_CLASSES_CONFIG),
+            plugins.newPlugins(config.getList(RestServerConfig.REST_EXTENSION_CLASSES_CONFIG),
                                config,
                                ConnectRestExtension.class);
         assertNotNull(connectRestExtensions);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/ConnectRestServerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/ConnectRestServerTest.java
@@ -29,14 +29,11 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.utils.LogCaptureAppender;
 import org.apache.kafka.connect.rest.ConnectRestExtension;
 import org.apache.kafka.connect.runtime.Herder;
-import org.apache.kafka.connect.runtime.WorkerConfig;
-import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
-import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -55,20 +52,21 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.apache.kafka.connect.runtime.WorkerConfig.ADMIN_LISTENERS_CONFIG;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
-public class RestServerTest {
+public class ConnectRestServerTest {
 
     private Herder herder;
     private Plugins plugins;
-    private RestServer server;
+    private ConnectRestServer server;
     private CloseableHttpClient httpClient;
     private Collection<CloseableHttpResponse> responses = new ArrayList<>();
 
@@ -94,18 +92,10 @@ public class RestServerTest {
         }
     }
 
-    private Map<String, String> baseWorkerProps() {
-        Map<String, String> workerProps = new HashMap<>();
-        workerProps.put(DistributedConfig.STATUS_STORAGE_TOPIC_CONFIG, "status-topic");
-        workerProps.put(DistributedConfig.CONFIG_TOPIC_CONFIG, "config-topic");
-        workerProps.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-        workerProps.put(DistributedConfig.GROUP_ID_CONFIG, "connect-test-group");
-        workerProps.put(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
-        workerProps.put(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
-        workerProps.put(DistributedConfig.OFFSET_STORAGE_TOPIC_CONFIG, "connect-offsets");
-        workerProps.put(WorkerConfig.LISTENERS_CONFIG, "HTTP://localhost:0");
-
-        return workerProps;
+    private Map<String, String> baseServerProps() {
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put(RestServerConfig.LISTENERS_CONFIG, "HTTP://localhost:0");
+        return configMap;
     }
 
     @Test
@@ -121,65 +111,60 @@ public class RestServerTest {
     @Test
     public void testAdvertisedUri() {
         // Advertised URI from listeners without protocol
-        Map<String, String> configMap = new HashMap<>(baseWorkerProps());
-        configMap.put(WorkerConfig.LISTENERS_CONFIG, "http://localhost:8080,https://localhost:8443");
-        DistributedConfig config = new DistributedConfig(configMap);
+        Map<String, String> configMap = new HashMap<>(baseServerProps());
+        configMap.put(RestServerConfig.LISTENERS_CONFIG, "http://localhost:8080,https://localhost:8443");
 
-        server = new RestServer(config);
+        server = new ConnectRestServer(null, configMap);
         Assert.assertEquals("http://localhost:8080/", server.advertisedUrl().toString());
         server.stop();
 
         // Advertised URI from listeners with protocol
-        configMap = new HashMap<>(baseWorkerProps());
-        configMap.put(WorkerConfig.LISTENERS_CONFIG, "http://localhost:8080,https://localhost:8443");
-        configMap.put(WorkerConfig.REST_ADVERTISED_LISTENER_CONFIG, "https");
-        config = new DistributedConfig(configMap);
+        configMap = new HashMap<>(baseServerProps());
+        configMap.put(RestServerConfig.LISTENERS_CONFIG, "http://localhost:8080,https://localhost:8443");
+        configMap.put(RestServerConfig.REST_ADVERTISED_LISTENER_CONFIG, "https");
 
-        server = new RestServer(config);
+        server = new ConnectRestServer(null, configMap);
         Assert.assertEquals("https://localhost:8443/", server.advertisedUrl().toString());
         server.stop();
 
         // Advertised URI from listeners with only SSL available
-        configMap = new HashMap<>(baseWorkerProps());
-        configMap.put(WorkerConfig.LISTENERS_CONFIG, "https://localhost:8443");
-        config = new DistributedConfig(configMap);
+        configMap = new HashMap<>(baseServerProps());
+        configMap.put(RestServerConfig.LISTENERS_CONFIG, "https://localhost:8443");
 
-        server = new RestServer(config);
+        server = new ConnectRestServer(null, configMap);
         Assert.assertEquals("https://localhost:8443/", server.advertisedUrl().toString());
         server.stop();
 
         // Listener is overriden by advertised values
-        configMap = new HashMap<>(baseWorkerProps());
-        configMap.put(WorkerConfig.LISTENERS_CONFIG, "https://localhost:8443");
-        configMap.put(WorkerConfig.REST_ADVERTISED_LISTENER_CONFIG, "http");
-        configMap.put(WorkerConfig.REST_ADVERTISED_HOST_NAME_CONFIG, "somehost");
-        configMap.put(WorkerConfig.REST_ADVERTISED_PORT_CONFIG, "10000");
-        config = new DistributedConfig(configMap);
+        configMap = new HashMap<>(baseServerProps());
+        configMap.put(RestServerConfig.LISTENERS_CONFIG, "https://localhost:8443");
+        configMap.put(RestServerConfig.REST_ADVERTISED_LISTENER_CONFIG, "http");
+        configMap.put(RestServerConfig.REST_ADVERTISED_HOST_NAME_CONFIG, "somehost");
+        configMap.put(RestServerConfig.REST_ADVERTISED_PORT_CONFIG, "10000");
 
-        server = new RestServer(config);
+        server = new ConnectRestServer(null, configMap);
         Assert.assertEquals("http://somehost:10000/", server.advertisedUrl().toString());
         server.stop();
 
         // correct listener is chosen when https listener is configured before http listener and advertised listener is http
-        configMap = new HashMap<>(baseWorkerProps());
-        configMap.put(WorkerConfig.LISTENERS_CONFIG, "https://encrypted-localhost:42069,http://plaintext-localhost:4761");
-        configMap.put(WorkerConfig.REST_ADVERTISED_LISTENER_CONFIG, "http");
-        config = new DistributedConfig(configMap);
-        server = new RestServer(config);
+        configMap = new HashMap<>(baseServerProps());
+        configMap.put(RestServerConfig.LISTENERS_CONFIG, "https://encrypted-localhost:42069,http://plaintext-localhost:4761");
+        configMap.put(RestServerConfig.REST_ADVERTISED_LISTENER_CONFIG, "http");
+
+        server = new ConnectRestServer(null, configMap);
         Assert.assertEquals("http://plaintext-localhost:4761/", server.advertisedUrl().toString());
         server.stop();
     }
 
     @Test
     public void testOptionsDoesNotIncludeWadlOutput() throws IOException {
-        Map<String, String> configMap = new HashMap<>(baseWorkerProps());
-        DistributedConfig workerConfig = new DistributedConfig(configMap);
+        Map<String, String> configMap = new HashMap<>(baseServerProps());
 
         doReturn(KAFKA_CLUSTER_ID).when(herder).kafkaClusterId();
         doReturn(plugins).when(herder).plugins();
-        doReturn(Collections.emptyList()).when(plugins).newPlugins(Collections.emptyList(), workerConfig, ConnectRestExtension.class);
+        expectEmptyRestExtensions();
 
-        server = new RestServer(workerConfig);
+        server = new ConnectRestServer(null, configMap);
         server.initializeServer();
         server.initializeResources(herder);
 
@@ -197,17 +182,16 @@ public class RestServerTest {
 
     public void checkCORSRequest(String corsDomain, String origin, String expectedHeader, String method)
         throws IOException {
-        Map<String, String> workerProps = baseWorkerProps();
-        workerProps.put(WorkerConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG, corsDomain);
-        workerProps.put(WorkerConfig.ACCESS_CONTROL_ALLOW_METHODS_CONFIG, method);
-        WorkerConfig workerConfig = new DistributedConfig(workerProps);
+        Map<String, String> configMap = baseServerProps();
+        configMap.put(RestServerConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG, corsDomain);
+        configMap.put(RestServerConfig.ACCESS_CONTROL_ALLOW_METHODS_CONFIG, method);
 
         doReturn(KAFKA_CLUSTER_ID).when(herder).kafkaClusterId();
         doReturn(plugins).when(herder).plugins();
-        doReturn(Collections.emptyList()).when(plugins).newPlugins(Collections.emptyList(), workerConfig, ConnectRestExtension.class);
+        expectEmptyRestExtensions();
         doReturn(Arrays.asList("a", "b")).when(herder).connectors();
 
-        server = new RestServer(workerConfig);
+        server = new ConnectRestServer(null, configMap);
         server.initializeServer();
         server.initializeResources(herder);
         URI serverUrl = server.advertisedUrl();
@@ -242,16 +226,15 @@ public class RestServerTest {
 
     @Test
     public void testStandaloneConfig() throws IOException  {
-        Map<String, String> workerProps = baseWorkerProps();
-        workerProps.put("offset.storage.file.filename", "/tmp");
-        WorkerConfig workerConfig = new StandaloneConfig(workerProps);
+        Map<String, String> configMap = baseServerProps();
+        configMap.put("offset.storage.file.filename", "/tmp");
 
         doReturn(KAFKA_CLUSTER_ID).when(herder).kafkaClusterId();
         doReturn(plugins).when(herder).plugins();
-        doReturn(Collections.emptyList()).when(plugins).newPlugins(Collections.emptyList(), workerConfig, ConnectRestExtension.class);
+        expectEmptyRestExtensions();
         doReturn(Arrays.asList("a", "b")).when(herder).connectors();
 
-        server = new RestServer(workerConfig);
+        server = new ConnectRestServer(null, configMap);
         server.initializeServer();
         server.initializeResources(herder);
         HttpRequest request = new HttpGet("/connectors");
@@ -262,17 +245,16 @@ public class RestServerTest {
 
     @Test
     public void testLoggersEndpointWithDefaults() throws IOException {
-        Map<String, String> configMap = new HashMap<>(baseWorkerProps());
-        DistributedConfig workerConfig = new DistributedConfig(configMap);
+        Map<String, String> configMap = new HashMap<>(baseServerProps());
 
         doReturn(KAFKA_CLUSTER_ID).when(herder).kafkaClusterId();
         doReturn(plugins).when(herder).plugins();
-        doReturn(Collections.emptyList()).when(plugins).newPlugins(Collections.emptyList(), workerConfig, ConnectRestExtension.class);
+        expectEmptyRestExtensions();
 
         // create some loggers in the process
         LoggerFactory.getLogger("a.b.c.s.W");
 
-        server = new RestServer(workerConfig);
+        server = new ConnectRestServer(null, configMap);
         server.initializeServer();
         server.initializeResources(herder);
 
@@ -292,14 +274,12 @@ public class RestServerTest {
 
     @Test
     public void testIndependentAdminEndpoint() throws IOException {
-        Map<String, String> configMap = new HashMap<>(baseWorkerProps());
-        configMap.put(ADMIN_LISTENERS_CONFIG, "http://localhost:0");
-
-        DistributedConfig workerConfig = new DistributedConfig(configMap);
+        Map<String, String> configMap = new HashMap<>(baseServerProps());
+        configMap.put(RestServerConfig.ADMIN_LISTENERS_CONFIG, "http://localhost:0");
 
         doReturn(KAFKA_CLUSTER_ID).when(herder).kafkaClusterId();
         doReturn(plugins).when(herder).plugins();
-        doReturn(Collections.emptyList()).when(plugins).newPlugins(Collections.emptyList(), workerConfig, ConnectRestExtension.class);
+        expectEmptyRestExtensions();
 
         // create some loggers in the process
         LoggerFactory.getLogger("a.b.c.s.W");
@@ -307,7 +287,7 @@ public class RestServerTest {
         LoggerFactory.getLogger("a.b.c.p.Y");
         LoggerFactory.getLogger("a.b.c.p.Z");
 
-        server = new RestServer(workerConfig);
+        server = new ConnectRestServer(null, configMap);
         server.initializeServer();
         server.initializeResources(herder);
 
@@ -322,16 +302,14 @@ public class RestServerTest {
 
     @Test
     public void testDisableAdminEndpoint() throws IOException {
-        Map<String, String> configMap = new HashMap<>(baseWorkerProps());
-        configMap.put(ADMIN_LISTENERS_CONFIG, "");
-
-        DistributedConfig workerConfig = new DistributedConfig(configMap);
+        Map<String, String> configMap = new HashMap<>(baseServerProps());
+        configMap.put(RestServerConfig.ADMIN_LISTENERS_CONFIG, "");
 
         doReturn(KAFKA_CLUSTER_ID).when(herder).kafkaClusterId();
         doReturn(plugins).when(herder).plugins();
-        doReturn(Collections.emptyList()).when(plugins).newPlugins(Collections.emptyList(), workerConfig, ConnectRestExtension.class);
+        expectEmptyRestExtensions();
 
-        server = new RestServer(workerConfig);
+        server = new ConnectRestServer(null, configMap);
         server.initializeServer();
         server.initializeResources(herder);
 
@@ -344,14 +322,13 @@ public class RestServerTest {
 
     @Test
     public void testRequestLogs() throws IOException, InterruptedException {
-        Map<String, String> configMap = new HashMap<>(baseWorkerProps());
-        DistributedConfig workerConfig = new DistributedConfig(configMap);
+        Map<String, String> configMap = new HashMap<>(baseServerProps());
 
         doReturn(KAFKA_CLUSTER_ID).when(herder).kafkaClusterId();
         doReturn(plugins).when(herder).plugins();
-        doReturn(Collections.emptyList()).when(plugins).newPlugins(Collections.emptyList(), workerConfig, ConnectRestExtension.class);
+        expectEmptyRestExtensions();
 
-        server = new RestServer(workerConfig);
+        server = new ConnectRestServer(null, configMap);
         server.initializeServer();
         server.initializeResources(herder);
 
@@ -388,17 +365,16 @@ public class RestServerTest {
 
     private void checkCustomizedHttpResponseHeaders(String headerConfig, Map<String, String> expectedHeaders)
             throws IOException  {
-        Map<String, String> workerProps = baseWorkerProps();
-        workerProps.put("offset.storage.file.filename", "/tmp");
-        workerProps.put(WorkerConfig.RESPONSE_HTTP_HEADERS_CONFIG, headerConfig);
-        WorkerConfig workerConfig = new DistributedConfig(workerProps);
+        Map<String, String> configMap = baseServerProps();
+        configMap.put("offset.storage.file.filename", "/tmp");
+        configMap.put(RestServerConfig.RESPONSE_HTTP_HEADERS_CONFIG, headerConfig);
 
         doReturn(KAFKA_CLUSTER_ID).when(herder).kafkaClusterId();
         doReturn(plugins).when(herder).plugins();
-        doReturn(Collections.emptyList()).when(plugins).newPlugins(Collections.emptyList(), workerConfig, ConnectRestExtension.class);
+        expectEmptyRestExtensions();
         doReturn(Arrays.asList("a", "b")).when(herder).connectors();
 
-        server = new RestServer(workerConfig);
+        server = new ConnectRestServer(null, configMap);
         server.initializeServer();
         server.initializeResources(herder);
         HttpRequest request = new HttpGet("/connectors");
@@ -441,5 +417,13 @@ public class RestServerTest {
     private static String prettyPrint(Map<String, ?> map) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
         return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(map);
+    }
+
+    private void expectEmptyRestExtensions() {
+        doReturn(Collections.emptyList()).when(plugins).newPlugins(
+                eq(Collections.emptyList()),
+                any(AbstractConfig.class),
+                eq(ConnectRestExtension.class)
+        );
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerConfigTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerConfigTest.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.rest;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.kafka.connect.runtime.rest.RestServerConfig.LISTENERS_DEFAULT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class RestServerConfigTest {
+
+    private static final List<String> VALID_HEADER_CONFIGS = Arrays.asList(
+            "add \t Cache-Control: no-cache, no-store, must-revalidate",
+            "add \r X-XSS-Protection: 1; mode=block",
+            "\n add Strict-Transport-Security: max-age=31536000; includeSubDomains",
+            "AdD   Strict-Transport-Security:  \r  max-age=31536000;  includeSubDomains",
+            "AdD \t Strict-Transport-Security : \n   max-age=31536000;  includeSubDomains",
+            "add X-Content-Type-Options: \r nosniff",
+            "Set \t X-Frame-Options: \t Deny\n ",
+            "seT \t X-Cache-Info: \t not cacheable\n ",
+            "seTDate \t Expires: \r 31540000000",
+            "adDdate \n Last-Modified: \t 0"
+    );
+
+    private static final List<String> INVALID_HEADER_CONFIGS = Arrays.asList(
+            "set \t",
+            "badaction \t X-Frame-Options:DENY",
+            "set add X-XSS-Protection:1",
+            "addX-XSS-Protection",
+            "X-XSS-Protection:",
+            "add set X-XSS-Protection: 1",
+            "add X-XSS-Protection:1 X-XSS-Protection:1 ",
+            "add X-XSS-Protection",
+            "set X-Frame-Options:DENY, add  :no-cache, no-store, must-revalidate "
+    );
+
+    @Test
+    public void testListenersConfigAllowedValues() {
+        Map<String, String> props = new HashMap<>();
+
+        // no value set for "listeners"
+        RestServerConfig config = RestServerConfig.forPublic(null, props);
+        assertEquals(LISTENERS_DEFAULT, config.listeners());
+
+        props.put(RestServerConfig.LISTENERS_CONFIG, "http://a.b:9999");
+        config = RestServerConfig.forPublic(null, props);
+        assertEquals(Arrays.asList("http://a.b:9999"), config.listeners());
+
+        props.put(RestServerConfig.LISTENERS_CONFIG, "http://a.b:9999, https://a.b:7812");
+        config = RestServerConfig.forPublic(null, props);
+        assertEquals(Arrays.asList("http://a.b:9999", "https://a.b:7812"), config.listeners());
+
+        config = RestServerConfig.forPublic(null, props);
+    }
+
+    @Test
+    public void testListenersConfigNotAllowedValues() {
+        Map<String, String> props = new HashMap<>();
+        assertEquals(LISTENERS_DEFAULT, RestServerConfig.forPublic(null, props).listeners());
+
+        props.put(RestServerConfig.LISTENERS_CONFIG, "");
+        ConfigException ce = assertThrows(ConfigException.class, () -> RestServerConfig.forPublic(null, props));
+        assertTrue(ce.getMessage().contains(" listeners"));
+
+        props.put(RestServerConfig.LISTENERS_CONFIG, ",,,");
+        ce = assertThrows(ConfigException.class, () -> RestServerConfig.forPublic(null, props));
+        assertTrue(ce.getMessage().contains(" listeners"));
+
+        props.put(RestServerConfig.LISTENERS_CONFIG, "http://a.b:9999,");
+        ce = assertThrows(ConfigException.class, () -> RestServerConfig.forPublic(null, props));
+        assertTrue(ce.getMessage().contains(" listeners"));
+
+        props.put(RestServerConfig.LISTENERS_CONFIG, "http://a.b:9999, ,https://a.b:9999");
+        ce = assertThrows(ConfigException.class, () -> RestServerConfig.forPublic(null, props));
+        assertTrue(ce.getMessage().contains(" listeners"));
+    }
+
+    @Test
+    public void testAdminListenersConfigAllowedValues() {
+        Map<String, String> props = new HashMap<>();
+
+        // no value set for "admin.listeners"
+        RestServerConfig config = RestServerConfig.forPublic(null, props);
+        assertNull("Default value should be null.", config.adminListeners());
+
+        props.put(RestServerConfig.ADMIN_LISTENERS_CONFIG, "");
+        config = RestServerConfig.forPublic(null, props);
+        assertTrue(config.adminListeners().isEmpty());
+
+        props.put(RestServerConfig.ADMIN_LISTENERS_CONFIG, "http://a.b:9999, https://a.b:7812");
+        config = RestServerConfig.forPublic(null, props);
+        assertEquals(Arrays.asList("http://a.b:9999", "https://a.b:7812"), config.adminListeners());
+
+        RestServerConfig.forPublic(null, props);
+    }
+
+    @Test
+    public void testAdminListenersNotAllowingEmptyStrings() {
+        Map<String, String> props = new HashMap<>();
+
+        props.put(RestServerConfig.ADMIN_LISTENERS_CONFIG, "http://a.b:9999,");
+        ConfigException ce = assertThrows(ConfigException.class, () -> RestServerConfig.forPublic(null, props));
+        assertTrue(ce.getMessage().contains(" admin.listeners"));
+    }
+
+    @Test
+    public void testAdminListenersNotAllowingBlankStrings() {
+        Map<String, String> props = new HashMap<>();
+        props.put(RestServerConfig.ADMIN_LISTENERS_CONFIG, "http://a.b:9999, ,https://a.b:9999");
+        assertThrows(ConfigException.class, () -> RestServerConfig.forPublic(null, props));
+    }
+
+    @Test
+    public void testInvalidHeaderConfigs() {
+        for (String config : INVALID_HEADER_CONFIGS) {
+            assertInvalidHeaderConfig(config);
+        }
+    }
+
+    @Test
+    public void testValidHeaderConfigs() {
+        for (String config : VALID_HEADER_CONFIGS) {
+            assertValidHeaderConfig(config);
+        }
+    }
+
+    private void assertInvalidHeaderConfig(String config) {
+        assertThrows(ConfigException.class, () -> RestServerConfig.validateHttpResponseHeaderConfig(config));
+    }
+
+    private void assertValidHeaderConfig(String config) {
+        RestServerConfig.validateHttpResponseHeaderConfig(config);
+    }
+
+    @Test
+    public void testInvalidSslClientAuthConfig() {
+        Map<String, String> props = new HashMap<>();
+
+        props.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "abc");
+        ConfigException ce = assertThrows(ConfigException.class, () -> RestServerConfig.forPublic(null, props));
+        assertTrue(ce.getMessage().contains(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG));
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.connect.runtime.rest.resources;
 
-import javax.crypto.Mac;
 import javax.ws.rs.core.HttpHeaders;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -29,7 +28,6 @@ import org.apache.kafka.connect.runtime.RestartRequest;
 import org.apache.kafka.connect.runtime.distributed.NotAssignedException;
 import org.apache.kafka.connect.runtime.distributed.NotLeaderException;
 import org.apache.kafka.connect.runtime.distributed.RebalanceNeededException;
-import org.apache.kafka.connect.runtime.rest.InternalRequestSignature;
 import org.apache.kafka.connect.runtime.rest.RestClient;
 import org.apache.kafka.connect.runtime.rest.RestServerConfig;
 import org.apache.kafka.connect.runtime.rest.entities.ActiveTopicsInfo;
@@ -62,7 +60,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -577,66 +574,6 @@ public class ConnectorsResourceTest {
     }
 
     @Test
-    public void testPutConnectorTaskConfigsNoInternalRequestSignature() throws Throwable {
-        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
-        expectAndCallbackResult(cb, null).when(herder).putTaskConfigs(
-            eq(CONNECTOR_NAME),
-            eq(TASK_CONFIGS),
-            cb.capture(),
-            any()
-        );
-
-        connectorsResource.putTaskConfigs(CONNECTOR_NAME, NULL_HEADERS, FORWARD, serializeAsBytes(TASK_CONFIGS));
-    }
-
-    @Test
-    public void testPutConnectorTaskConfigsWithInternalRequestSignature() throws Throwable {
-        final String signatureAlgorithm = "HmacSHA256";
-        final String encodedSignature = "Kv1/OSsxzdVIwvZ4e30avyRIVrngDfhzVUm/kAZEKc4=";
-
-        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
-        final ArgumentCaptor<InternalRequestSignature> signatureCapture = ArgumentCaptor.forClass(InternalRequestSignature.class);
-        expectAndCallbackResult(cb, null).when(herder).putTaskConfigs(
-            eq(CONNECTOR_NAME),
-            eq(TASK_CONFIGS),
-            cb.capture(),
-            signatureCapture.capture()
-        );
-
-        HttpHeaders headers = mock(HttpHeaders.class);
-        when(headers.getHeaderString(InternalRequestSignature.SIGNATURE_ALGORITHM_HEADER))
-            .thenReturn(signatureAlgorithm);
-        when(headers.getHeaderString(InternalRequestSignature.SIGNATURE_HEADER))
-            .thenReturn(encodedSignature);
-
-        connectorsResource.putTaskConfigs(CONNECTOR_NAME, headers, FORWARD, serializeAsBytes(TASK_CONFIGS));
-
-        InternalRequestSignature expectedSignature = new InternalRequestSignature(
-            serializeAsBytes(TASK_CONFIGS),
-            Mac.getInstance(signatureAlgorithm),
-            Base64.getDecoder().decode(encodedSignature)
-        );
-        assertEquals(
-            expectedSignature,
-            signatureCapture.getValue()
-        );
-    }
-
-    @Test
-    public void testPutConnectorTaskConfigsConnectorNotFound() {
-        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
-        expectAndCallbackException(cb, new NotFoundException("not found")).when(herder).putTaskConfigs(
-            eq(CONNECTOR_NAME),
-            eq(TASK_CONFIGS),
-            cb.capture(),
-            any()
-        );
-
-        assertThrows(NotFoundException.class, () -> connectorsResource.putTaskConfigs(CONNECTOR_NAME, NULL_HEADERS,
-            FORWARD, serializeAsBytes(TASK_CONFIGS)));
-    }
-
-    @Test
     public void testRestartConnectorAndTasksConnectorNotFound() {
         RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, true, false);
         final ArgumentCaptor<Callback<ConnectorStateInfo>> cb = ArgumentCaptor.forClass(Callback.class);
@@ -695,55 +632,6 @@ public class ConnectorsResourceTest {
         assertEquals(CONNECTOR_NAME, ((ConnectorStateInfo) response.getEntity()).name());
         assertEquals(state.state(), ((ConnectorStateInfo) response.getEntity()).connector().state());
         assertEquals(Response.Status.ACCEPTED.getStatusCode(), response.getStatus());
-    }
-
-    @Test
-    public void testFenceZombiesNoInternalRequestSignature() throws Throwable {
-        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
-        expectAndCallbackResult(cb, null)
-            .when(herder).fenceZombieSourceTasks(eq(CONNECTOR_NAME), cb.capture(), isNull());
-
-        connectorsResource.fenceZombies(CONNECTOR_NAME, NULL_HEADERS, FORWARD, serializeAsBytes(null));
-    }
-
-    @Test
-    public void testFenceZombiesWithInternalRequestSignature() throws Throwable {
-        final String signatureAlgorithm = "HmacSHA256";
-        final String encodedSignature = "Kv1/OSsxzdVIwvZ4e30avyRIVrngDfhzVUm/kAZEKc4=";
-
-        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
-        final ArgumentCaptor<InternalRequestSignature> signatureCapture = ArgumentCaptor.forClass(InternalRequestSignature.class);
-        expectAndCallbackResult(cb, null)
-            .when(herder).fenceZombieSourceTasks(eq(CONNECTOR_NAME), cb.capture(), signatureCapture.capture());
-
-        HttpHeaders headers = mock(HttpHeaders.class);
-        when(headers.getHeaderString(InternalRequestSignature.SIGNATURE_ALGORITHM_HEADER))
-            .thenReturn(signatureAlgorithm);
-        when(headers.getHeaderString(InternalRequestSignature.SIGNATURE_HEADER))
-            .thenReturn(encodedSignature);
-
-        connectorsResource.fenceZombies(CONNECTOR_NAME, headers, FORWARD, serializeAsBytes(null));
-
-        InternalRequestSignature expectedSignature = new InternalRequestSignature(
-                serializeAsBytes(null),
-                Mac.getInstance(signatureAlgorithm),
-                Base64.getDecoder().decode(encodedSignature)
-        );
-        assertEquals(
-                expectedSignature,
-                signatureCapture.getValue()
-        );
-    }
-
-    @Test
-    public void testFenceZombiesConnectorNotFound() throws Throwable {
-        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
-
-        expectAndCallbackException(cb, new NotFoundException("not found"))
-            .when(herder).fenceZombieSourceTasks(eq(CONNECTOR_NAME), cb.capture(), any());
-
-        assertThrows(NotFoundException.class,
-                () -> connectorsResource.fenceZombies(CONNECTOR_NAME, NULL_HEADERS, FORWARD, serializeAsBytes(null)));
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/InternalConnectResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/InternalConnectResourceTest.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.rest.resources;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.connect.errors.NotFoundException;
+import org.apache.kafka.connect.runtime.Herder;
+import org.apache.kafka.connect.runtime.rest.InternalRequestSignature;
+import org.apache.kafka.connect.runtime.rest.RestServerConfig;
+import org.apache.kafka.connect.util.Callback;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Stubber;
+
+import javax.crypto.Mac;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.UriInfo;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
+public class InternalConnectResourceTest {
+
+    private static final Boolean FORWARD = true;
+    private static final String CONNECTOR_NAME = "test";
+    private static final HttpHeaders NULL_HEADERS = null;
+    private static final List<Map<String, String>> TASK_CONFIGS = new ArrayList<>();
+    static {
+        TASK_CONFIGS.add(Collections.singletonMap("config", "value"));
+        TASK_CONFIGS.add(Collections.singletonMap("config", "other_value"));
+    }
+    private static final String FENCE_PATH = "/connectors/" + CONNECTOR_NAME + "/fence";
+    private static final String TASK_CONFIGS_PATH = "/connectors/" + CONNECTOR_NAME + "/tasks";
+
+    @Mock
+    private UriInfo uriInfo;
+    @Mock
+    private Herder herder;
+    @Mock
+    private RestServerConfig serverConfig;
+
+    private InternalConnectResource internalResource;
+
+    @Before
+    public void setup() {
+        internalResource = new InternalConnectResource(herder, serverConfig);
+        internalResource.uriInfo = uriInfo;
+    }
+
+    @Test
+    public void testPutConnectorTaskConfigsNoInternalRequestSignature() throws Throwable {
+        @SuppressWarnings("unchecked")
+        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackResult(cb, null).when(herder).putTaskConfigs(
+                eq(CONNECTOR_NAME),
+                eq(TASK_CONFIGS),
+                cb.capture(),
+                any()
+        );
+        expectRequestPath(TASK_CONFIGS_PATH);
+
+        internalResource.putTaskConfigs(CONNECTOR_NAME, NULL_HEADERS, FORWARD, serializeAsBytes(TASK_CONFIGS));
+    }
+
+    @Test
+    public void testPutConnectorTaskConfigsWithInternalRequestSignature() throws Throwable {
+        final String signatureAlgorithm = "HmacSHA256";
+        final String encodedSignature = "Kv1/OSsxzdVIwvZ4e30avyRIVrngDfhzVUm/kAZEKc4=";
+
+        @SuppressWarnings("unchecked")
+        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
+        final ArgumentCaptor<InternalRequestSignature> signatureCapture = ArgumentCaptor.forClass(InternalRequestSignature.class);
+        expectAndCallbackResult(cb, null).when(herder).putTaskConfigs(
+                eq(CONNECTOR_NAME),
+                eq(TASK_CONFIGS),
+                cb.capture(),
+                signatureCapture.capture()
+        );
+
+        HttpHeaders headers = mock(HttpHeaders.class);
+        when(headers.getHeaderString(InternalRequestSignature.SIGNATURE_ALGORITHM_HEADER))
+                .thenReturn(signatureAlgorithm);
+        when(headers.getHeaderString(InternalRequestSignature.SIGNATURE_HEADER))
+                .thenReturn(encodedSignature);
+        expectRequestPath(TASK_CONFIGS_PATH);
+
+        internalResource.putTaskConfigs(CONNECTOR_NAME, headers, FORWARD, serializeAsBytes(TASK_CONFIGS));
+
+        InternalRequestSignature expectedSignature = new InternalRequestSignature(
+                serializeAsBytes(TASK_CONFIGS),
+                Mac.getInstance(signatureAlgorithm),
+                Base64.getDecoder().decode(encodedSignature)
+        );
+        assertEquals(
+                expectedSignature,
+                signatureCapture.getValue()
+        );
+    }
+
+    @Test
+    public void testPutConnectorTaskConfigsConnectorNotFound() {
+        @SuppressWarnings("unchecked")
+        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackException(cb, new NotFoundException("not found")).when(herder).putTaskConfigs(
+                eq(CONNECTOR_NAME),
+                eq(TASK_CONFIGS),
+                cb.capture(),
+                any()
+        );
+        expectRequestPath(TASK_CONFIGS_PATH);
+
+        assertThrows(NotFoundException.class, () -> internalResource.putTaskConfigs(CONNECTOR_NAME, NULL_HEADERS,
+                FORWARD, serializeAsBytes(TASK_CONFIGS)));
+    }
+
+    @Test
+    public void testFenceZombiesNoInternalRequestSignature() throws Throwable {
+        @SuppressWarnings("unchecked")
+        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackResult(cb, null)
+                .when(herder).fenceZombieSourceTasks(eq(CONNECTOR_NAME), cb.capture(), isNull());
+        expectRequestPath(FENCE_PATH);
+
+        internalResource.fenceZombies(CONNECTOR_NAME, NULL_HEADERS, FORWARD, serializeAsBytes(null));
+    }
+
+    @Test
+    public void testFenceZombiesWithInternalRequestSignature() throws Throwable {
+        final String signatureAlgorithm = "HmacSHA256";
+        final String encodedSignature = "Kv1/OSsxzdVIwvZ4e30avyRIVrngDfhzVUm/kAZEKc4=";
+
+        @SuppressWarnings("unchecked")
+        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
+        final ArgumentCaptor<InternalRequestSignature> signatureCapture = ArgumentCaptor.forClass(InternalRequestSignature.class);
+        expectAndCallbackResult(cb, null)
+                .when(herder).fenceZombieSourceTasks(eq(CONNECTOR_NAME), cb.capture(), signatureCapture.capture());
+
+        HttpHeaders headers = mock(HttpHeaders.class);
+        when(headers.getHeaderString(InternalRequestSignature.SIGNATURE_ALGORITHM_HEADER))
+                .thenReturn(signatureAlgorithm);
+        when(headers.getHeaderString(InternalRequestSignature.SIGNATURE_HEADER))
+                .thenReturn(encodedSignature);
+        expectRequestPath(FENCE_PATH);
+
+        internalResource.fenceZombies(CONNECTOR_NAME, headers, FORWARD, serializeAsBytes(null));
+
+        InternalRequestSignature expectedSignature = new InternalRequestSignature(
+                serializeAsBytes(null),
+                Mac.getInstance(signatureAlgorithm),
+                Base64.getDecoder().decode(encodedSignature)
+        );
+        assertEquals(
+                expectedSignature,
+                signatureCapture.getValue()
+        );
+    }
+
+    @Test
+    public void testFenceZombiesConnectorNotFound() throws Throwable {
+        @SuppressWarnings("unchecked")
+        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
+
+        expectAndCallbackException(cb, new NotFoundException("not found"))
+                .when(herder).fenceZombieSourceTasks(eq(CONNECTOR_NAME), cb.capture(), any());
+        expectRequestPath(FENCE_PATH);
+
+        assertThrows(NotFoundException.class,
+                () -> internalResource.fenceZombies(CONNECTOR_NAME, NULL_HEADERS, FORWARD, serializeAsBytes(null)));
+    }
+
+    private <T> byte[] serializeAsBytes(final T value) throws IOException {
+        return new ObjectMapper().writeValueAsBytes(value);
+    }
+
+    private <T> Stubber expectAndCallbackResult(final ArgumentCaptor<Callback<T>> cb, final T value) {
+        return doAnswer(invocation -> {
+            cb.getValue().onCompletion(null, value);
+            return null;
+        });
+    }
+
+    private <T> Stubber expectAndCallbackException(final ArgumentCaptor<Callback<T>> cb, final Throwable t) {
+        return doAnswer(invocation -> {
+            cb.getValue().onCompletion(t, null);
+            return null;
+        });
+    }
+
+    private void expectRequestPath(String path) {
+        when(uriInfo.getPath()).thenReturn(path);
+    }
+
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/util/SSLUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/util/SSLUtilsTest.java
@@ -16,11 +16,8 @@
  */
 package org.apache.kafka.connect.runtime.rest.util;
 
-import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.config.SslConfigs;
-import org.apache.kafka.connect.runtime.WorkerConfig;
-import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
-import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
+import org.apache.kafka.connect.runtime.rest.RestServerConfig;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.Assert;
 import org.junit.Test;
@@ -31,17 +28,6 @@ import java.util.Map;
 
 @SuppressWarnings("deprecation")
 public class SSLUtilsTest {
-    private static final Map<String, String> DEFAULT_CONFIG = new HashMap<>();
-    static {
-        // The WorkerConfig base class has some required settings without defaults
-        DEFAULT_CONFIG.put(DistributedConfig.STATUS_STORAGE_TOPIC_CONFIG, "status-topic");
-        DEFAULT_CONFIG.put(DistributedConfig.CONFIG_TOPIC_CONFIG, "config-topic");
-        DEFAULT_CONFIG.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-        DEFAULT_CONFIG.put(DistributedConfig.GROUP_ID_CONFIG, "connect-test-group");
-        DEFAULT_CONFIG.put(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
-        DEFAULT_CONFIG.put(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
-        DEFAULT_CONFIG.put(DistributedConfig.OFFSET_STORAGE_TOPIC_CONFIG, "connect-offsets");
-    }
 
     @Test
     public void testGetOrDefault() {
@@ -58,7 +44,7 @@ public class SSLUtilsTest {
 
     @Test
     public void testCreateServerSideSslContextFactory() {
-        Map<String, String> configMap = new HashMap<>(DEFAULT_CONFIG);
+        Map<String, String> configMap = new HashMap<>();
         configMap.put("ssl.keystore.location", "/path/to/keystore");
         configMap.put("ssl.keystore.password", "123456");
         configMap.put("ssl.key.password", "123456");
@@ -76,7 +62,7 @@ public class SSLUtilsTest {
         configMap.put("ssl.keymanager.algorithm", "SunX509");
         configMap.put("ssl.trustmanager.algorithm", "PKIX");
 
-        DistributedConfig config = new DistributedConfig(configMap);
+        RestServerConfig config = RestServerConfig.forPublic(null, configMap);
         SslContextFactory ssl = SSLUtils.createServerSideSslContextFactory(config);
 
         Assert.assertEquals("file:///path/to/keystore", ssl.getKeyStorePath());
@@ -96,7 +82,7 @@ public class SSLUtilsTest {
 
     @Test
     public void testCreateClientSideSslContextFactory() {
-        Map<String, String> configMap = new HashMap<>(DEFAULT_CONFIG);
+        Map<String, String> configMap = new HashMap<>();
         configMap.put("ssl.keystore.location", "/path/to/keystore");
         configMap.put("ssl.keystore.password", "123456");
         configMap.put("ssl.key.password", "123456");
@@ -114,7 +100,7 @@ public class SSLUtilsTest {
         configMap.put("ssl.keymanager.algorithm", "SunX509");
         configMap.put("ssl.trustmanager.algorithm", "PKIX");
 
-        DistributedConfig config = new DistributedConfig(configMap);
+        RestServerConfig config = RestServerConfig.forPublic(null, configMap);
         SslContextFactory ssl = SSLUtils.createClientSideSslContextFactory(config);
 
         Assert.assertEquals("file:///path/to/keystore", ssl.getKeyStorePath());
@@ -134,10 +120,7 @@ public class SSLUtilsTest {
 
     @Test
     public void testCreateServerSideSslContextFactoryDefaultValues() {
-        Map<String, String> configMap = new HashMap<>(DEFAULT_CONFIG);
-        configMap.put(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG, "/tmp/offset/file");
-        configMap.put(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
-        configMap.put(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
+        Map<String, String> configMap = new HashMap<>();
         configMap.put("ssl.keystore.location", "/path/to/keystore");
         configMap.put("ssl.keystore.password", "123456");
         configMap.put("ssl.key.password", "123456");
@@ -147,7 +130,7 @@ public class SSLUtilsTest {
         configMap.put("ssl.cipher.suites", "SSL_RSA_WITH_RC4_128_SHA,SSL_RSA_WITH_RC4_128_MD5");
         configMap.put("ssl.secure.random.implementation", "SHA1PRNG");
 
-        DistributedConfig config = new DistributedConfig(configMap);
+        RestServerConfig config = RestServerConfig.forPublic(null, configMap);
         SslContextFactory ssl = SSLUtils.createServerSideSslContextFactory(config);
 
         Assert.assertEquals(SslConfigs.DEFAULT_SSL_KEYSTORE_TYPE, ssl.getKeyStoreType());
@@ -162,10 +145,7 @@ public class SSLUtilsTest {
 
     @Test
     public void testCreateClientSideSslContextFactoryDefaultValues() {
-        Map<String, String> configMap = new HashMap<>(DEFAULT_CONFIG);
-        configMap.put(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG, "/tmp/offset/file");
-        configMap.put(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
-        configMap.put(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
+        Map<String, String> configMap = new HashMap<>();
         configMap.put("ssl.keystore.location", "/path/to/keystore");
         configMap.put("ssl.keystore.password", "123456");
         configMap.put("ssl.key.password", "123456");
@@ -175,7 +155,7 @@ public class SSLUtilsTest {
         configMap.put("ssl.cipher.suites", "SSL_RSA_WITH_RC4_128_SHA,SSL_RSA_WITH_RC4_128_MD5");
         configMap.put("ssl.secure.random.implementation", "SHA1PRNG");
 
-        DistributedConfig config = new DistributedConfig(configMap);
+        RestServerConfig config = RestServerConfig.forPublic(null, configMap);
         SslContextFactory ssl = SSLUtils.createClientSideSslContextFactory(config);
 
         Assert.assertEquals(SslConfigs.DEFAULT_SSL_KEYSTORE_TYPE, ssl.getKeyStoreType());

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
@@ -54,7 +54,7 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.WorkerConfig.BOOTSTRAP_SERVERS_CONFIG;
-import static org.apache.kafka.connect.runtime.WorkerConfig.LISTENERS_CONFIG;
+import static org.apache.kafka.connect.runtime.rest.RestServerConfig.LISTENERS_CONFIG;
 import static org.apache.kafka.connect.runtime.distributed.DistributedConfig.CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG;
 import static org.apache.kafka.connect.runtime.distributed.DistributedConfig.CONFIG_TOPIC_CONFIG;
 import static org.apache.kafka.connect.runtime.distributed.DistributedConfig.OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG;


### PR DESCRIPTION
Implements the REST-related changes from [KIP-710](https://cwiki.apache.org/confluence/display/KAFKA/KIP-710%3A+Full+support+for+distributed+mode+in+dedicated+MirrorMaker+2.0+clusters). Changes for the `ConfigProvider` mechanism are not included.

An integration test is added to validate that a multi-node dedicated MirrorMaker 2 cluster can be brought up and function properly. Partly as a bonus, and partly because it was actually the easiest way to force intra-cluster communication to take place, exactly-once support is enabled as of this test.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
