### PR TITLE
fix: fail when trying to disable remote storage on an enabled topic

### DIFF
--- a/core/src/main/scala/kafka/zk/AdminZkClient.scala
+++ b/core/src/main/scala/kafka/zk/AdminZkClient.scala
@@ -24,6 +24,7 @@ import kafka.server.{ConfigEntityName, ConfigType, DynamicConfig, KafkaConfig}
 import kafka.utils._
 import kafka.utils.Implicits._
 import org.apache.kafka.admin.{AdminUtils, BrokerMetadata}
+import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.common.errors._
 import org.apache.kafka.common.internals.Topic
@@ -477,6 +478,14 @@ class AdminZkClient(zkClient: KafkaZkClient,
     Topic.validate(topic)
     if (!zkClient.topicExists(topic))
       throw new UnknownTopicOrPartitionException(s"Topic '$topic' does not exist.")
+
+    // fix: workaround to fail when trying to disable tiered storage instead of silently update value while logging warning
+    val currentRemoteStorageEnable = zkClient.getEntityConfigs(ConfigType.Topic, topic).getProperty(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "false")
+    val newRemoteStorageEnable = configs.getProperty(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, currentRemoteStorageEnable)
+    if (java.lang.Boolean.parseBoolean(currentRemoteStorageEnable) && !java.lang.Boolean.parseBoolean(newRemoteStorageEnable)) {
+      throw new InvalidConfigurationException(s"Disabling remote log on the topic is not supported.")
+    }
+
     // remove the topic overrides
     LogConfig.validate(configs,
       kafkaConfig.map(_.extractLogConfigMap).getOrElse(Collections.emptyMap()),

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
@@ -599,4 +599,18 @@ class DynamicConfigChangeUnitTest {
     configHandler.maybeBootstrapRemoteLogComponents(topic, Seq(log0), isRemoteLogEnabledBeforeUpdate)
     verify(rlm, never()).onLeadershipChange(any(), any(), any())
   }
+
+  @Test
+  def testDisableRemoteLogStorageOnTopicOnAlreadyEnabledTopic(): Unit = {
+    val rlm: RemoteLogManager = mock(classOf[RemoteLogManager])
+    val replicaManager: ReplicaManager = mock(classOf[ReplicaManager])
+    when(replicaManager.remoteLogManager).thenReturn(Some(rlm))
+
+    val isRemoteLogEnabledBeforeUpdate = true
+    val configHandler: TopicConfigHandler = new TopicConfigHandler(replicaManager, null, null, None)
+    val newProps = new Properties()
+    newProps.put(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "false")
+    assertThrows(classOf[IllegalArgumentException], () => configHandler.maybeFailIfDisablingRemoteStorage(newProps, isRemoteLogEnabledBeforeUpdate))
+    verify(rlm, never()).onLeadershipChange(any(), any(), any())
+  }
 }


### PR DESCRIPTION
Able to fail-fast and avoid updating unexpected config: 

```
demo main !2 ?3 > $KAFKA_HOME/bin/kafka-configs.sh --bootstrap-server localhost:9092 --entity-type topics --entity-name t2 --alter --add-config remote.storage.enable=false
Error while executing config command with args '--bootstrap-server localhost:9092 --entity-type topics --entity-name t2 --alter --add-config remote.storage.enable=false'
java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.InvalidConfigurationException: Disabling remote log on the topic is not supported.
        at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396)
        at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2096)
        at org.apache.kafka.common.internals.KafkaFutureImpl.get(KafkaFutureImpl.java:180)
        at kafka.admin.ConfigCommand$.alterConfig(ConfigCommand.scala:359)
        at kafka.admin.ConfigCommand$.processCommand(ConfigCommand.scala:326)
        at kafka.admin.ConfigCommand$.main(ConfigCommand.scala:97)
        at kafka.admin.ConfigCommand.main(ConfigCommand.scala)
Caused by: org.apache.kafka.common.errors.InvalidConfigurationException: Disabling remote log on the topic is not supported.

demo main !2 ?3 > $KAFKA_HOME/bin/kafka-configs.sh --bootstrap-server localhost:9092 --entity-type topics --entity-name t2 --describe
Dynamic configs for topic t2 are:
  remote.storage.enable=true sensitive=false synonyms={DYNAMIC_TOPIC_CONFIG:remote.storage.enable=true}
  segment.bytes=1048576 sensitive=false synonyms={DYNAMIC_TOPIC_CONFIG:segment.bytes=1048576, DEFAULT_CONFIG:log.segment.bytes=1073741824}
  retention.ms=-1 sensitive=false synonyms={DYNAMIC_TOPIC_CONFIG:retention.ms=-1}
  local.retention.bytes=1 sensitive=false synonyms={DYNAMIC_TOPIC_CONFIG:local.retention.bytes=1, DEFAULT_CONFIG:log.local.retention.bytes=-2}
  retention.bytes=104857600 sensitive=false synonyms={DYNAMIC_TOPIC_CONFIG:retention.bytes=104857600, DEFAULT_CONFIG:log.retention.bytes=-1}

```