### PR TITLE
fix: re-open closed txn index channel

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/TransactionIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/TransactionIndex.java
@@ -211,6 +211,7 @@ public class TransactionIndex implements Closeable {
     }
 
     private FileChannel channelOrNull() {
+        maybeReopenChannel();
         return maybeChannel.orElse(null);
     }
 
@@ -259,6 +260,16 @@ public class TransactionIndex implements Closeable {
             }
 
         };
+    }
+
+    private void maybeReopenChannel() {
+        if (maybeChannel.isPresent() && !maybeChannel.get().isOpen()) {
+            try {
+                maybeChannel = Optional.of(openChannel());
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to re-open txn index file channel", e);
+            }
+        }
     }
 
 }


### PR DESCRIPTION
When timeout is not large enough on fetching remote indexes, the Transaction index may fall into a closed state, that is not recoverable.

To avoid failing on every fetch request on the same txn index until restarted, this PR proposes to reopen a closed file channel.
