### PR TITLE
Temporal workaround for KAFKA-15776

### DIFF
--- a/core/src/main/scala/kafka/server/DelayedRemoteFetch.scala
+++ b/core/src/main/scala/kafka/server/DelayedRemoteFetch.scala
@@ -37,8 +37,10 @@ class DelayedRemoteFetch(remoteFetchTask: Future[Void],
                          fetchParams: FetchParams,
                          localReadResults: Seq[(TopicIdPartition, LogReadResult)],
                          replicaManager: ReplicaManager,
-                         responseCallback: Seq[(TopicIdPartition, FetchPartitionData)] => Unit)
-  extends DelayedOperation(fetchParams.maxWaitMs) {
+                         responseCallback: Seq[(TopicIdPartition, FetchPartitionData)] => Unit,
+                         // TODO: temporal workaround, wait for workaround on KAFKA-15776, see KIP-1018
+                         maxWaitMs: Long)
+  extends DelayedOperation(maxWaitMs) {
 
   /**
    * The operation can be completed if:

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1357,8 +1357,10 @@ class ReplicaManager(val config: KafkaConfig,
         return Some(createLogReadResult(e))
     }
 
+    // TODO: temporal workaround, wait for workaround on KAFKA-15776, see KIP-1018
+    val maxWaitMs = config.remoteLogManagerConfig.fetchRemoteMaxWaitMs()
     val remoteFetch = new DelayedRemoteFetch(remoteFetchTask, remoteFetchResult, remoteFetchInfo,
-      fetchPartitionStatus, params, logReadResults, this, responseCallback)
+      fetchPartitionStatus, params, logReadResults, this, responseCallback, maxWaitMs)
 
     delayedRemoteFetchPurgatory.tryCompleteElseWatch(remoteFetch, Seq(key))
     None

--- a/core/src/test/scala/integration/kafka/server/DelayedRemoteFetchTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DelayedRemoteFetchTest.scala
@@ -40,6 +40,7 @@ class DelayedRemoteFetchTest {
   private val logStartOffset = 0L
   private val currentLeaderEpoch = Optional.of[Integer](10)
   private val replicaId = 1
+  private val remoteFetchMaxWaitMs = 30000L
 
   private val fetchStatus = FetchPartitionStatus(
     startOffsetMetadata = new LogOffsetMetadata(fetchOffset),
@@ -65,7 +66,7 @@ class DelayedRemoteFetchTest {
     val logReadInfo = buildReadResult(Errors.NONE, highWatermark, leaderLogStartOffset)
 
     val delayedRemoteFetch = new DelayedRemoteFetch(null, future, fetchInfo, Seq(topicIdPartition -> fetchStatus), fetchParams,
-      Seq(topicIdPartition -> logReadInfo), replicaManager, callback)
+      Seq(topicIdPartition -> logReadInfo), replicaManager, callback, remoteFetchMaxWaitMs)
 
     when(replicaManager.getPartitionOrException(topicIdPartition.topicPartition))
       .thenReturn(mock(classOf[Partition]))
@@ -103,7 +104,7 @@ class DelayedRemoteFetchTest {
     val logReadInfo = buildReadResult(Errors.NONE)
 
     val delayedRemoteFetch = new DelayedRemoteFetch(null, future, fetchInfo, Seq(topicIdPartition -> fetchStatus), fetchParams,
-      Seq(topicIdPartition -> logReadInfo), replicaManager, callback)
+      Seq(topicIdPartition -> logReadInfo), replicaManager, callback, remoteFetchMaxWaitMs)
 
     // delayed remote fetch should still be able to complete
     assertTrue(delayedRemoteFetch.tryComplete())
@@ -134,7 +135,7 @@ class DelayedRemoteFetchTest {
     val logReadInfo = buildReadResult(Errors.FENCED_LEADER_EPOCH)
 
     val delayedRemoteFetch = new DelayedRemoteFetch(null, future, fetchInfo, Seq(topicIdPartition -> fetchStatus), fetchParams,
-      Seq(topicIdPartition -> logReadInfo), replicaManager, callback)
+      Seq(topicIdPartition -> logReadInfo), replicaManager, callback, remoteFetchMaxWaitMs)
 
     assertTrue(delayedRemoteFetch.tryComplete())
     assertTrue(delayedRemoteFetch.isCompleted)

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerConfig.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerConfig.java
@@ -143,6 +143,12 @@ public final class RemoteLogManagerConfig {
             "less than or equal to `log.retention.bytes` value.";
     public static final Long DEFAULT_LOG_LOCAL_RETENTION_BYTES = -2L;
 
+    // TODO: temporal workaround, wait for workaround on KAFKA-15776, see KIP-1018
+    public static final String FETCH_REMOTE_MAX_WAIT_MS_PROP = "fetch.remote.max.wait.ms";
+    public static final String FETCH_REMOTE_MAX_WAIT_MS_DOC = "Fetch timeout for reading remote log";
+    public static final int DEFAULT_FETCH_REMOTE_MAX_WAIT_MS = 2000;
+
+
     public static final ConfigDef CONFIG_DEF = new ConfigDef();
 
     static {
@@ -255,7 +261,13 @@ public final class RemoteLogManagerConfig {
                                   DEFAULT_LOG_LOCAL_RETENTION_BYTES,
                                   atLeast(DEFAULT_LOG_LOCAL_RETENTION_BYTES),
                                   MEDIUM,
-                                  LOG_LOCAL_RETENTION_BYTES_DOC);
+                                  LOG_LOCAL_RETENTION_BYTES_DOC)
+                  .define(FETCH_REMOTE_MAX_WAIT_MS_PROP,
+                                  LONG,
+                                  DEFAULT_FETCH_REMOTE_MAX_WAIT_MS,
+                                  atLeast(1),
+                                  MEDIUM,
+                                  FETCH_REMOTE_MAX_WAIT_MS_DOC);
     }
 
     private final boolean enableRemoteStorageSystem;
@@ -277,6 +289,7 @@ public final class RemoteLogManagerConfig {
     private final HashMap<String, Object> remoteLogMetadataManagerProps;
     private final String remoteLogMetadataManagerListenerName;
     private final int remoteLogMetadataCustomMetadataMaxBytes;
+    private final long fetchRemoteMaxWaitMs;
 
     public RemoteLogManagerConfig(AbstractConfig config) {
         this(config.getBoolean(REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP),
@@ -301,7 +314,8 @@ public final class RemoteLogManagerConfig {
              config.getString(REMOTE_LOG_METADATA_MANAGER_CONFIG_PREFIX_PROP),
              config.getString(REMOTE_LOG_METADATA_MANAGER_CONFIG_PREFIX_PROP) != null
                  ? config.originalsWithPrefix(config.getString(REMOTE_LOG_METADATA_MANAGER_CONFIG_PREFIX_PROP))
-                 : Collections.emptyMap());
+                 : Collections.emptyMap(),
+             config.getLong(FETCH_REMOTE_MAX_WAIT_MS_PROP));
     }
 
     // Visible for testing
@@ -323,7 +337,8 @@ public final class RemoteLogManagerConfig {
                                   String remoteStorageManagerPrefix,
                                   Map<String, Object> remoteStorageManagerProps, /* properties having keys stripped out with remoteStorageManagerPrefix */
                                   String remoteLogMetadataManagerPrefix,
-                                  Map<String, Object> remoteLogMetadataManagerProps /* properties having keys stripped out with remoteLogMetadataManagerPrefix */
+                                  Map<String, Object> remoteLogMetadataManagerProps, /* properties having keys stripped out with remoteLogMetadataManagerPrefix */
+                                  long fetchRemoteMaxWaitMs
     ) {
         this.enableRemoteStorageSystem = enableRemoteStorageSystem;
         this.remoteStorageManagerClassName = remoteStorageManagerClassName;
@@ -344,6 +359,7 @@ public final class RemoteLogManagerConfig {
         this.remoteLogMetadataManagerProps = new HashMap<>(remoteLogMetadataManagerProps);
         this.remoteLogMetadataManagerListenerName = remoteLogMetadataManagerListenerName;
         this.remoteLogMetadataCustomMetadataMaxBytes = remoteLogMetadataCustomMetadataMaxBytes;
+        this.fetchRemoteMaxWaitMs = fetchRemoteMaxWaitMs;
     }
 
     public boolean enableRemoteStorageSystem() {
@@ -420,6 +436,10 @@ public final class RemoteLogManagerConfig {
 
     public Map<String, Object> remoteLogMetadataManagerProps() {
         return Collections.unmodifiableMap(remoteLogMetadataManagerProps);
+    }
+
+    public long fetchRemoteMaxWaitMs() {
+        return fetchRemoteMaxWaitMs;
     }
 
     @Override

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerConfigTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerConfigTest.java
@@ -48,7 +48,7 @@ public class RemoteLogManagerConfigTest {
                 = new RemoteLogManagerConfig(true, "dummy.remote.storage.class", "dummy.remote.storage.class.path",
                                              remoteLogMetadataManagerClass, "dummy.remote.log.metadata.class.path",
                                              "listener.name", 1024 * 1024L, 1, 60000L, 100L, 60000L, 0.3, 10, 100, 100,
-                                             rsmPrefix, rsmProps, rlmmPrefix, rlmmProps);
+                                             rsmPrefix, rsmProps, rlmmPrefix, rlmmProps, 30000);
 
         Map<String, Object> props = extractProps(expectedRemoteLogManagerConfig);
         rsmProps.forEach((k, v) -> props.put(rsmPrefix + k, v));
@@ -98,6 +98,7 @@ public class RemoteLogManagerConfigTest {
                   remoteLogManagerConfig.remoteStorageManagerPrefix());
         props.put(RemoteLogManagerConfig.REMOTE_LOG_METADATA_MANAGER_CONFIG_PREFIX_PROP,
                   remoteLogManagerConfig.remoteLogMetadataManagerPrefix());
+        props.put(RemoteLogManagerConfig.FETCH_REMOTE_MAX_WAIT_MS_PROP, remoteLogManagerConfig.fetchRemoteMaxWaitMs());
         return props;
     }
 }


### PR DESCRIPTION
By adding a server side config, remote fetch operations can be managed by Kafka operators.

See https://issues.apache.org/jira/browse/KAFKA-15776
