### PR TITLE
mirrormaker: restrict the number of checkpoint connector tasks

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConfig.java
@@ -41,6 +41,10 @@ public class MirrorCheckpointConfig extends MirrorConnectorConfig {
     public static final String CHECKPOINTS_TOPIC_REPLICATION_FACTOR_DOC = "Replication factor for checkpoints topic.";
     public static final short CHECKPOINTS_TOPIC_REPLICATION_FACTOR_DEFAULT = 3;
 
+    protected static final String CHECKPOINTS_TASKS_MAXIMUM = "checkpoints.tasks.max";
+    protected static final String CHECKPOINTS_TASKS_MAXIMUM_DOC = "Maximum number of checkpoint connector tasks.";
+    private static final int CHECKPOINTS_TASKS_MAX_DEFAULT = 1;
+
     protected static final String TASK_CONSUMER_GROUPS = "task.assigned.groups";
 
     public static final String CONSUMER_POLL_TIMEOUT_MILLIS = "consumer.poll.timeout.ms";
@@ -122,6 +126,10 @@ public class MirrorCheckpointConfig extends MirrorConnectorConfig {
             // negative interval to disable
             return Duration.ofMillis(-1);
         }
+    }
+
+    Integer getCheckpointConnectorTaskMax() {
+        return getInt(CHECKPOINTS_TASKS_MAXIMUM);
     }
 
     Map<String, String> taskConfigForConsumerGroups(List<String> groups, int taskIndex) {
@@ -250,6 +258,12 @@ public class MirrorCheckpointConfig extends MirrorConnectorConfig {
                         CHECKPOINTS_TOPIC_REPLICATION_FACTOR_DEFAULT,
                         ConfigDef.Importance.LOW,
                         CHECKPOINTS_TOPIC_REPLICATION_FACTOR_DOC)
+                .define(
+                        CHECKPOINTS_TASKS_MAXIMUM,
+                        ConfigDef.Type.INT,
+                        CHECKPOINTS_TASKS_MAX_DEFAULT,
+                        ConfigDef.Importance.LOW,
+                        CHECKPOINTS_TASKS_MAXIMUM_DOC)
                 .define(
                         OFFSET_SYNCS_TOPIC_LOCATION,
                         ConfigDef.Type.STRING,

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnector.java
@@ -150,8 +150,10 @@ public class MirrorCheckpointConnector extends SourceConnector {
             return Collections.emptyList();
         }
 
-        int numTasks = Math.min(maxTasks, knownConsumerGroups.size());
-        List<List<String>> groupsPartitioned = ConnectorUtils.groupPartitions(new ArrayList<>(knownConsumerGroups), numTasks);
+        final int limitCheckpointConnectorsTasks = Math.min(maxTasks, config.getCheckpointConnectorTaskMax());
+        final int numTasks = Math.min(limitCheckpointConnectorsTasks, knownConsumerGroups.size());
+        log.info("Limiting the CheckpointConnector tasks to {}", numTasks);
+        final List<List<String>> groupsPartitioned = ConnectorUtils.groupPartitions(new ArrayList<>(knownConsumerGroups), numTasks);
         return IntStream.range(0, numTasks)
                 .mapToObj(i -> config.taskConfigForConsumerGroups(groupsPartitioned.get(i), i))
                 .collect(Collectors.toList());


### PR DESCRIPTION
The MirrorCheckpointConnector uses the global tasks max for setting the number of maximum tasks. This can cause extreme burden on single Kafka broker when hundreds of checkpoint tasks are consuming from from the single partition topic.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
