### PR TITLE
[MINOR] add max replication factor to Aiven policies

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/AivenTopicPolicy.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/AivenTopicPolicy.java
@@ -4,6 +4,7 @@
 package org.apache.kafka.controller;
 
 import org.apache.kafka.common.Configurable;
+import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.ApiError;
@@ -29,12 +30,12 @@ final class AivenTopicPolicy implements Configurable {
     }
 
     ApiError validateTopicCreation(
-        final String topic,
+        final CreatableTopic topic,
         final int partitions,
         final TimelineHashMap<Uuid, ReplicationControlManager.TopicControlInfo> topics
     ) {
         // Always allow for excluded topics.
-        if (excludedTopics.contains(topic)) {
+        if (excludedTopics.contains(topic.name())) {
             return ApiError.NONE;
         }
 
@@ -70,6 +71,15 @@ final class AivenTopicPolicy implements Configurable {
                     return new ApiError(Errors.POLICY_VIOLATION,
                         String.format("Partition limit exceeded: maximum %d user partitions allowed", maxUserPartitions));
                 }
+            }
+        }
+        
+        if (config.maxReplicationFactor().isPresent()) {
+            final int maxReplicationFactor = config.maxReplicationFactor().get();
+
+            if (topic.replicationFactor() > maxReplicationFactor) {
+                return new ApiError(Errors.POLICY_VIOLATION,
+                    String.format("Replication factor limit exceeded: maximum %d replication factor allowed", maxReplicationFactor));
             }
         }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/AivenTopicPolicyConfig.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/AivenTopicPolicyConfig.java
@@ -18,6 +18,7 @@ final class AivenTopicPolicyConfig extends AbstractConfig {
     private static final String MAX_USER_TOPICS = PREFIX + "max.user.topics";
     private static final String MAX_USER_PARTITIONS = PREFIX + "max.user.partitions";
     private static final String MAX_PARTITIONS_PER_USER_TOPIC = PREFIX + "max.partitions.per.user.topic";
+    private static final String MAX_REPLICATION_FACTOR = PREFIX + "max.replication.factor";
     private static final String EXCLUDED_TOPICS = PREFIX + "excluded.topics";
 
     private static ConfigDef configDef() {
@@ -47,6 +48,14 @@ final class AivenTopicPolicyConfig extends AbstractConfig {
                 "Maximum number of partitions per user topic (optional, must be >= 1 if provided)"
             )
             .define(
+                MAX_REPLICATION_FACTOR,
+                ConfigDef.Type.INT,
+                null,
+                new OptionalRange(ConfigDef.Range.atLeast(1)),
+                ConfigDef.Importance.MEDIUM,
+                "Maximum replication factor for user topics (optional, must be >= 1 if provided)"
+            )
+            .define(
                 EXCLUDED_TOPICS,
                 ConfigDef.Type.LIST,
                 null,
@@ -69,6 +78,10 @@ final class AivenTopicPolicyConfig extends AbstractConfig {
 
     Optional<Integer> maxPartitionsPerUserTopic() {
         return Optional.ofNullable(getInt(MAX_PARTITIONS_PER_USER_TOPIC));
+    }
+
+    Optional<Integer> maxReplicationFactor() {
+        return Optional.ofNullable(getInt(MAX_REPLICATION_FACTOR));
     }
 
     Set<String> excludedTopics() {

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -874,7 +874,7 @@ public class ReplicationControlManager {
                 }
             }
             if (aivenTopicPolicy != null) {
-                ApiError aivenPolicyError = aivenTopicPolicy.validateTopicCreation(topic.name(), newParts.size(), topics);
+                ApiError aivenPolicyError = aivenTopicPolicy.validateTopicCreation(topic, newParts.size(), topics);
                 if (aivenPolicyError.isFailure()) return aivenPolicyError;
             }
             ApiError error = maybeCheckCreateTopicPolicy(() -> {
@@ -896,7 +896,7 @@ public class ReplicationControlManager {
             short replicationFactor = topic.replicationFactor() == -1 ?
                 defaultReplicationFactor : topic.replicationFactor();
             if (aivenTopicPolicy != null) {
-                ApiError aivenPolicyError = aivenTopicPolicy.validateTopicCreation(topic.name(), numPartitions, topics);
+                ApiError aivenPolicyError = aivenTopicPolicy.validateTopicCreation(topic, numPartitions, topics);
                 if (aivenPolicyError.isFailure()) return aivenPolicyError;
             }
             try {


### PR DESCRIPTION
We will also need to control the max replication factor in some clusters
(in particular, we want to enforce RF 1).

This adds a new limit on top of https://github.com/aiven/kafka/pull/65
