### PR TITLE
MINOR: support regex when excluding topics from Aiven policies

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/AivenTopicPolicy.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/AivenTopicPolicy.java
@@ -4,6 +4,8 @@
 package org.apache.kafka.controller;
 
 import org.apache.kafka.common.Configurable;
+import java.util.stream.Collectors;
+import java.util.regex.Pattern;
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.protocol.Errors;
@@ -11,7 +13,6 @@ import org.apache.kafka.common.requests.ApiError;
 import org.apache.kafka.timeline.TimelineHashMap;
 
 import java.util.Map;
-import java.util.Set;
 
 /**
  * The policy class that allows putting limitations such as "max user topics", "max user partitions",
@@ -21,12 +22,15 @@ final class AivenTopicPolicy implements Configurable {
     private static final long LATEST_SNAPSHOT = Long.MAX_VALUE;
 
     private volatile AivenTopicPolicyConfig config;
-    private volatile Set<String> excludedTopics;
+    private volatile Pattern excludedTopicsPattern;
 
     @Override
     public void configure(final Map<String, ?> configs) {
         this.config = new AivenTopicPolicyConfig(configs);
-        this.excludedTopics = config.excludedTopics();
+        this.excludedTopicsPattern = Pattern.compile(
+            config.excludedTopics().stream()
+            .collect(Collectors.joining("|"))
+        );
     }
 
     ApiError validateTopicCreation(
@@ -35,7 +39,7 @@ final class AivenTopicPolicy implements Configurable {
         final TimelineHashMap<Uuid, ReplicationControlManager.TopicControlInfo> topics
     ) {
         // Always allow for excluded topics.
-        if (excludedTopics.contains(topic.name())) {
+        if (excludedTopicsPattern.matcher(topic.name()).matches()) {
             return ApiError.NONE;
         }
 
@@ -51,7 +55,7 @@ final class AivenTopicPolicy implements Configurable {
             int currentUserTopics = 0;
             int currentUserPartitions = 0;
             for (final var value : topics.values()) {
-                if (!excludedTopics.contains(value.name())) {
+                if (!excludedTopicsPattern.matcher(value.name()).matches()) {
                     currentUserTopics += 1;
                     currentUserPartitions += value.numPartitions(LATEST_SNAPSHOT);
                 }
@@ -93,7 +97,7 @@ final class AivenTopicPolicy implements Configurable {
         final TimelineHashMap<Uuid, ReplicationControlManager.TopicControlInfo> topics
     ) {
         // Always allow for excluded topics.
-        if (excludedTopics.contains(topic)) {
+        if (excludedTopicsPattern.matcher(topic).matches()) {
             return ApiError.NONE;
         }
 
@@ -109,7 +113,7 @@ final class AivenTopicPolicy implements Configurable {
             final int maxUserPartitions = config.maxUserPartitions().get();
             int currentUserPartitions = 0;
             for (final var value : topics.values()) {
-                if (!excludedTopics.contains(value.name())) {
+                if (!excludedTopicsPattern.matcher(value.name()).matches()) {
                     currentUserPartitions += value.numPartitions(LATEST_SNAPSHOT);
                 }
             }

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -4384,15 +4384,18 @@ public class ReplicationControlManagerTest {
         }
     }
 
-    void testAivenTopicPolicyCreateTopicMaxUserTopics() {
-        String excludedTopic1 = "__consumer_offsets";
-        String excludedTopic2 = "__transaction_state";
+    @ParameterizedTest
+    @CsvSource({
+        "__consumer_offsets,__consumer_offsets,__transaction_state,__transaction_state",
+        "__connect_offsets-12345,__connect_offsets-.*,__connect_configs-98765,__connect_configs-.*",
+    })
+    void testAivenTopicPolicyCreateTopicMaxUserTopics(String excludedTopic1, String excludedTopic1Pattern, String excludedTopic2, String excludedTopic2Pattern) {
         String topic1 = "topic1";
         String topic2 = "topic2";
 
         ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
             .setStaticConfig("aiven.topic.policy.max.user.topics", 1)
-            .setStaticConfig("aiven.topic.policy.excluded.topics", String.format("%s,%s", excludedTopic1, excludedTopic2))
+            .setStaticConfig("aiven.topic.policy.excluded.topics", String.format("%s,%s", excludedTopic1Pattern, excludedTopic2Pattern))
             .build();
         ctx.registerBrokers(0);
         ctx.unfenceBrokers(0);
@@ -4461,10 +4464,20 @@ public class ReplicationControlManagerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void testAivenTopicPolicyCreateTopicMaxUserPartitions(boolean autoAssignment) {
-        String excludedTopic1 = "__consumer_offsets";
-        String excludedTopic2 = "__transaction_state";
+    @CsvSource({
+        "__consumer_offsets,__consumer_offsets,__transaction_state,__transaction_state,withAutoAssignment",
+        "__connect_offsets-12345,__connect_offsets-.*,__connect_configs-98765,__connect_configs-.*,withAutoAssignment",
+        "__consumer_offsets,__consumer_offsets,__transaction_state,__transaction_state,withoutAutoAssignment",
+        "__connect_offsets-12345,__connect_offsets-.*,__connect_configs-98765,__connect_configs-.*,withoutAutoAssignment",
+    })
+    void testAivenTopicPolicyCreateTopicMaxUserPartitions(
+        String excludedTopic1,
+        String excludedTopic1Pattern,
+        String excludedTopic2,
+        String excludedTopic2Pattern,
+        String withOrWithoutAutoAssignment
+    ) {
+        boolean autoAssignment = withOrWithoutAutoAssignment.equals("withAutoAssignment");
         String topic1 = "topic1";
         String topic2 = "topic2";
 
@@ -4577,9 +4590,14 @@ public class ReplicationControlManagerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void testAivenTopicPolicyCreateTopicMaxPartitionsPerUserTopic(boolean autoAssignment) {
-        String excludedTopic1 = "__consumer_offsets";
+    @CsvSource({
+        "__consumer_offsets,__consumer_offsets,withAutoAssignment",
+        "__connect_offsets-12345,__connect_offsets-.*,withAutoAssignment",
+        "__consumer_offsets,__consumer_offsets,withoutAutoAssignment",
+        "__connect_offsets-12345,__connect_offsets-.*,withoutAutoAssignment",
+    })
+    void testAivenTopicPolicyCreateTopicMaxPartitionsPerUserTopic(String excludedTopic1, String excludedTopic1Pattern, String withOrWithoutAutoAssignment) {
+        boolean autoAssignment = withOrWithoutAutoAssignment.equals("withAutoAssignment");
         String topic1 = "topic1";
 
         ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
@@ -4669,9 +4687,12 @@ public class ReplicationControlManagerTest {
         assertEquals(NONE.code(), topicResult.errorCode());
     }
 
-    @Test
-    void testAivenTopicPolicyCreatePartitionMaxUserPartitions() {
-        String excludedTopic1 = "__consumer_offsets";
+    @ParameterizedTest
+    @CsvSource({
+        "__consumer_offsets,__consumer_offsets",
+        "__connect_offsets-12345,__connect_offsets-.*",
+    })
+    void testAivenTopicPolicyCreatePartitionMaxUserPartitions(String excludedTopic1, String excludedTopic1Pattern) {
         String topic1 = "topic1";
 
         ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
@@ -4731,9 +4752,12 @@ public class ReplicationControlManagerTest {
         ctx.replay(result5.records());
     }
 
-    @Test
-    void testAivenTopicPolicyCreatePartitionsMaxPartitionsPerUserTopic() {
-        String excludedTopic1 = "__consumer_offsets";
+    @ParameterizedTest
+    @CsvSource({
+        "__consumer_offsets,__consumer_offsets",
+        "__connect_offsets-12345,__connect_offsets-.*",
+    })
+    void testAivenTopicPolicyCreatePartitionsMaxPartitionsPerUserTopic(String excludedTopic1, String excludedTopic1Pattern) {
         String topic1 = "topic1";
 
         ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()


### PR DESCRIPTION
For Kafka Connect we can have variable topic names, so we can't have a
exact match when excluding topics.
